### PR TITLE
Add initial Playwright e2e test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ rust_analyzer_target
 # Added by cargo
 
 /target
+
+# Node / Playwright
+node_modules/
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,47 @@
+# End-to-end tests
+
+Playwright drives the app in a real browser against a `dx serve` instance of
+`mailiner-app`.
+
+## Prerequisites
+
+- Node.js 20+
+- [`dioxus-cli`](https://dioxuslabs.com/learn/0.7/getting_started) (`dx`) on
+  `PATH`, matching the version pinned in `.github/workflows/deploy-pages.yml`
+- The `wasm32-unknown-unknown` Rust target: `rustup target add wasm32-unknown-unknown`
+
+## Setup
+
+```bash
+npm install
+npx playwright install --with-deps chromium
+```
+
+## Running the tests
+
+```bash
+npm run test:e2e
+```
+
+This starts `dx serve -p mailiner-app` automatically (see `playwright.config.ts`)
+and waits for it to come up before running the tests. The first run can take a
+few minutes since it compiles the whole workspace to WASM.
+
+`mailiner-app`'s `build.rs` bakes an `IMAP_PASSWORD` value in at compile time.
+The config supplies a placeholder automatically, so no `.env` file is
+required just to bring the app up; connecting to a real IMAP account still
+needs the usual local setup described in the top-level `README.md` (including
+running `ws-tcp-proxy`).
+
+Useful variations:
+
+```bash
+# interactive UI mode
+npm run test:e2e:ui
+
+# open the HTML report from the last run
+npm run test:e2e:report
+
+# point tests at an already-running dev server instead of spawning one
+MAILINER_E2E_BASE_URL=http://127.0.0.1:8080 npx playwright test
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -3,6 +3,9 @@
 Playwright drives the app in a real browser against a `dx serve` instance of
 `mailiner-app`.
 
+All commands below are run from the repository root — `package.json` and
+`playwright.config.ts` live there, not inside `e2e/`.
+
 ## Prerequisites
 
 - Node.js 20+
@@ -28,10 +31,11 @@ and waits for it to come up before running the tests. The first run can take a
 few minutes since it compiles the whole workspace to WASM.
 
 `mailiner-app`'s `build.rs` bakes an `IMAP_PASSWORD` value in at compile time.
-The config supplies a placeholder automatically, so no `.env` file is
-required just to bring the app up; connecting to a real IMAP account still
-needs the usual local setup described in the top-level `README.md` (including
-running `ws-tcp-proxy`).
+`playwright.config.ts` loads a repo-root `.env` (if present) and forwards
+`IMAP_PASSWORD` from it, falling back to a placeholder otherwise, so no
+`.env` file is required just to bring the app up. Connecting to a real IMAP
+account still needs the usual local setup described in the top-level
+`README.md` (including running `ws-tcp-proxy`).
 
 Useful variations:
 

--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('loads the main layout', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.locator('#app')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "mailiner-e2e",
       "version": "0.1.0",
       "devDependencies": {
-        "@playwright/test": "^1.55.0"
+        "@playwright/test": "^1.55.0",
+        "dotenv": "^17.4.2"
       }
     },
     "node_modules/@playwright/test": {
@@ -25,6 +26,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "mailiner-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mailiner-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mailiner-e2e",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Playwright end-to-end tests for the Mailiner web app",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:e2e:report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.0"
+    "@playwright/test": "^1.55.0",
+    "dotenv": "^17.4.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+// Load repo-root .env (the same file build.rs reads via the `dotenv` crate)
+// so a real IMAP_PASSWORD set there is used instead of the placeholder below.
+dotenv.config();
 
 const PORT = process.env.MAILINER_E2E_PORT ?? '8080';
 const BASE_URL = process.env.MAILINER_E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.MAILINER_E2E_PORT ?? '8080';
+const BASE_URL = process.env.MAILINER_E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+/**
+ * Mailiner is a Dioxus/WASM app served via `dx serve`. The first build
+ * compiles the whole workspace to wasm32-unknown-unknown, which can take
+ * several minutes, so timeouts here are generous compared to a typical
+ * JS dev server.
+ */
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: `dx serve -p mailiner-app --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 5 * 60_000,
+    env: {
+      // build.rs bakes IMAP_PASSWORD in at compile time; a real value is
+      // only needed for actually logging into an IMAP account. Falls back
+      // to whatever a local .env already provides.
+      IMAP_PASSWORD: process.env.IMAP_PASSWORD ?? 'e2e-placeholder',
+    },
+  },
+});


### PR DESCRIPTION
Sets up @playwright/test to drive mailiner-app in a real browser via
`dx serve`, with a smoke test and docs for running it locally.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E2pXr54Z6MCK5e2c3C5uPc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up end-to-end tests with `@playwright/test` for `mailiner-app`, running in Chromium against `dx serve`. Adds a smoke test and npm scripts for local and CI runs.

- **New Features**
  - Playwright config spawns `dx serve -p mailiner-app` and waits for readiness. Override with `MAILINER_E2E_BASE_URL` or `MAILINER_E2E_PORT`.
  - Loads repo-root `.env` via `dotenv`; `IMAP_PASSWORD` from `.env` takes precedence, falling back to a placeholder only if unset.
  - Smoke test (`e2e/tests/app.spec.ts`) loads `/` and verifies `#app` is visible.
  - Scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:report`. `e2e/README.md` clarifies commands run from the repo root with setup steps.
  - CI-friendly defaults (retries on CI, single worker, GitHub reporter). Updates `.gitignore` for Node/Playwright artifacts.

<sup>Written for commit 676ea7c0a746708ef8a9f4f68704bde18eb04ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mailiner-net/mailiner-rs/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

