### PR TITLE
ci: restrict Cloudflare Pages deploy to main branch

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,6 +2,8 @@ name: Build & Deploy (Cloudflare Pages)
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The push trigger fired for every branch and deployed using the
triggering branch's ref name, so any push (including PR branches)
would deploy to Cloudflare Pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the Cloudflare Pages deploy workflow to run only on pushes to the main branch, preventing deployments from PR/feature branches.
Adds a branches: [main] filter under on.push in .github/workflows/deploy-pages.yml.

<sup>Written for commit 83e5f39a0356f3c229a46d8206e79e3fdd23be4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mailiner-net/mailiner-rs/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

