### PR TITLE
fix(core): make MessageId folder-scoped

### DIFF
--- a/crates/mailiner-app/src/core_event.rs
+++ b/crates/mailiner-app/src/core_event.rs
@@ -11,7 +11,7 @@ use futures_util::future::{Either, select};
 use mailiner_core::connector::EmailConnector;
 use mailiner_core::models::TransferEncoding;
 use mailiner_core::submit::{SendErrorKind, SubmitRequest};
-use mailiner_core::{EnvelopeFlag, FolderId, MailboxRole, MessageId as CoreMessageId, MessageSort};
+use mailiner_core::{EnvelopeFlag, FolderId, MailboxRole, MessageSort};
 
 use crate::account::AccountId;
 use crate::account_config::AccountConfig;
@@ -1198,14 +1198,13 @@ async fn handle_select_message(
     };
 
     let folder_id = FolderId::new(mailbox_id.to_string());
-    let core_id = CoreMessageId::new(message_id.to_string());
     info!(
         "Loading message {} in {}",
         message_id,
         mailbox_id.to_string()
     );
 
-    match load_message(connector, &folder_id, &core_id).await {
+    match load_message(connector, &folder_id, &message_id).await {
         Ok(loaded) => {
             if ctx.selection.read().focus() != Some(&message_id) {
                 return;
@@ -1222,7 +1221,11 @@ async fn handle_select_message(
             if was_unread && auto_mark_read {
                 apply_read_flag(ctx, std::slice::from_ref(&message_id), true);
                 if let Err(e) = connector
-                    .update_envelope_flags(&folder_id, &[core_id], &[(EnvelopeFlag::Read, true)])
+                    .update_envelope_flags(
+                        &folder_id,
+                        std::slice::from_ref(&message_id),
+                        &[(EnvelopeFlag::Read, true)],
+                    )
                     .await
                 {
                     warn!("Auto-mark as read failed for {}: {}", message_id, e);
@@ -1402,7 +1405,7 @@ fn restore_snapshots(
             for (snap, id) in snapshots.iter_mut().zip(ids) {
                 let mut next = (*snap.message).clone();
                 next.id = id.clone();
-                next.envelope.id = CoreMessageId::new(id.to_string());
+                next.envelope.id = id.clone();
                 snap.message = Arc::new(next);
             }
         }
@@ -1424,10 +1427,8 @@ fn restore_snapshots(
     }
 }
 
-fn core_message_ids(ids: &[MessageId]) -> Vec<CoreMessageId> {
-    ids.iter()
-        .map(|id| CoreMessageId::new(id.to_string()))
-        .collect()
+fn core_message_ids(ids: &[MessageId]) -> Vec<MessageId> {
+    ids.to_vec()
 }
 
 async fn handle_mark_read(
@@ -1538,10 +1539,7 @@ async fn handle_move_messages(
                 .get(&dest_mailbox_id)
                 .map(|n| n.title().to_string())
                 .unwrap_or_else(|| dest_mailbox_id.to_string());
-            let dest_ids: Vec<MessageId> = dest_uids
-                .into_iter()
-                .map(|id| MessageId::from(id.to_string()))
-                .collect();
+            let dest_ids = dest_uids;
             if dest_ids.len() == snapshots.len() && !dest_ids.is_empty() {
                 ctx.show_toast(ToastAction::moved(
                     dest_label,
@@ -1626,10 +1624,7 @@ async fn handle_move_to_trash(
             if unread_n != 0 {
                 bump_mailbox_unread(ctx, &trash_id, unread_n, false);
             }
-            let dest_ids: Vec<MessageId> = dest_uids
-                .into_iter()
-                .map(|id| MessageId::from(id.to_string()))
-                .collect();
+            let dest_ids = dest_uids;
             if dest_ids.len() == snapshots.len() && !dest_ids.is_empty() {
                 ctx.show_toast(ToastAction::trashed(MoveUndo {
                     from: trash_id,
@@ -1723,10 +1718,7 @@ async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, u
                     } else if unread_n != 0 {
                         bump_mailbox_unread(ctx, &undo.from, -unread_n, false);
                     }
-                    let new_ids: Vec<MessageId> = new_uids
-                        .into_iter()
-                        .map(|id| MessageId::from(id.to_string()))
-                        .collect();
+                    let new_ids = new_uids;
                     restore_snapshots(ctx, &undo.to, undo.snapshots, Some(&new_ids));
                     ctx.show_toast(ToastAction::info("Undone"));
                 }
@@ -1814,14 +1806,13 @@ async fn handle_download_attachment(
     );
 
     let folder_id = FolderId::new(mailbox_id.to_string());
-    let core_id = CoreMessageId::new(message_id.to_string());
     info!(
         "Downloading attachment section {} for message {}",
         section, message_id
     );
 
     let stream_result = connector
-        .stream_raw_part(&folder_id, &core_id, &section)
+        .stream_raw_part(&folder_id, &message_id, &section)
         .await;
 
     let mut stream = match stream_result {

--- a/crates/mailiner-app/src/formatter/html.rs
+++ b/crates/mailiner-app/src/formatter/html.rs
@@ -222,14 +222,14 @@ fn ammonia_clean(html: &str, allow_remote: bool) -> String {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use mailiner_core::ids::{MessageId, MessagePartId};
+    use mailiner_core::ids::{FolderId, MessageId, MessagePartId};
     use mailiner_core::models::{PartKind, TransferEncoding};
 
     fn html_part(html: &str) -> MessagePart {
         let now = Utc::now();
         MessagePart {
             id: MessagePartId::new("html"),
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             path: vec!["1".into()],
             kind: PartKind::TextHtml,
             content_type: "text/html".into(),
@@ -252,7 +252,7 @@ mod tests {
         let now = Utc::now();
         MessagePart {
             id: MessagePartId::new("img"),
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             path: vec!["2".into()],
             kind: PartKind::Image,
             content_type: "image/png".into(),
@@ -286,7 +286,7 @@ mod tests {
         let now = Utc::now();
         let svg = MessagePart {
             id: MessagePartId::new("svg"),
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             path: vec!["2".into()],
             kind: PartKind::Image,
             content_type: "image/svg+xml".into(),

--- a/crates/mailiner-app/src/formatter/mod.rs
+++ b/crates/mailiner-app/src/formatter/mod.rs
@@ -80,14 +80,14 @@ pub(crate) fn text_content(part: &MessagePart) -> Option<&str> {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use mailiner_core::ids::{MessageId, MessagePartId};
+    use mailiner_core::ids::{FolderId, MessageId, MessagePartId};
     use mailiner_core::models::{MessageContent, PartKind, TransferEncoding};
 
     fn part(kind: PartKind, ct: &str, text: &str) -> MessagePart {
         let now = Utc::now();
         MessagePart {
             id: MessagePartId::new("p1"),
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             path: vec!["TEXT".into()],
             kind,
             content_type: ct.into(),

--- a/crates/mailiner-app/src/message.rs
+++ b/crates/mailiner-app/src/message.rs
@@ -1,33 +1,13 @@
 use chrono::{DateTime, Utc};
 use mailiner_core::{EmailAddr, EmailAddress, Envelope};
-use std::fmt;
+
+pub use mailiner_core::MessageId;
 
 /// Distinct mid-saturation swatches for placeholder sender avatars.
 const AVATAR_COLORS: &[&str] = &[
     "#4C6EF5", "#0CA678", "#F08C00", "#E64980", "#7048E8", "#1098AD", "#F76707", "#37B24D",
     "#C2255C", "#364FC7",
 ];
-
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub struct MessageId(String);
-
-impl MessageId {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for MessageId {
-    fn from(id: String) -> Self {
-        Self(id)
-    }
-}
-
-impl fmt::Display for MessageId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Message {
@@ -154,7 +134,7 @@ mod tests {
 impl From<Envelope> for Message {
     fn from(envelope: Envelope) -> Self {
         Self {
-            id: MessageId::from(envelope.id.to_string()),
+            id: envelope.id.clone(),
             subject: envelope.subject.clone().unwrap_or_default(),
             from: envelope
                 .from

--- a/crates/mailiner-app/src/message_loader.rs
+++ b/crates/mailiner-app/src/message_loader.rs
@@ -146,7 +146,7 @@ mod tests {
     fn loads_multipart_prefers_html_content() {
         let connector = MockConnector::new();
         let folder = FolderId::new("inbox");
-        let msg = MessageId::new("1");
+        let msg = MessageId::new(folder.clone(), "1");
         let loaded = block_on(load_message::<NullStream, _>(&connector, &folder, &msg)).unwrap();
 
         assert_eq!(loaded.envelope_id, msg);
@@ -173,7 +173,7 @@ mod tests {
     fn content_parts_decoded_attachment_not_fetched() {
         let connector = MockConnector::new();
         let folder = FolderId::new("inbox");
-        let msg = MessageId::new("42");
+        let msg = MessageId::new(folder.clone(), "42");
         let loaded = block_on(load_message::<NullStream, _>(&connector, &folder, &msg)).unwrap();
 
         for p in loaded.attachments() {

--- a/crates/mailiner-app/src/selection.rs
+++ b/crates/mailiner-app/src/selection.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     fn id(s: &str) -> MessageId {
-        MessageId::from(s.to_string())
+        MessageId::new(mailiner_core::FolderId::new("INBOX"), s)
     }
 
     #[test]

--- a/crates/mailiner-app/src/toast.rs
+++ b/crates/mailiner-app/src/toast.rs
@@ -174,7 +174,7 @@ mod tests {
     fn dummy_msg(id: &str) -> Arc<Message> {
         let now = Utc::now();
         let envelope = Envelope {
-            id: mailiner_core::MessageId::new(id),
+            id: mailiner_core::MessageId::new(FolderId::new("INBOX"), id),
             account_id: AccountId::new("a"),
             folder_id: FolderId::new("INBOX"),
             subject: Some("s".into()),
@@ -216,7 +216,7 @@ mod tests {
         let undo = MoveUndo {
             from: MailboxId::from("Trash".to_string()),
             to: MailboxId::from("INBOX".to_string()),
-            dest_ids: vec![MessageId::from("9".to_string())],
+            dest_ids: vec![MessageId::new(FolderId::new("INBOX"), "9")],
             snapshots: vec![RemovedMessage {
                 index: 0,
                 message: dummy_msg("1"),

--- a/crates/mailiner-composer/src/reply/prefill.rs
+++ b/crates/mailiner-composer/src/reply/prefill.rs
@@ -286,7 +286,7 @@ mod tests {
 
     fn env_with_from(from: &str) -> Envelope {
         Envelope {
-            id: MessageId::new("1"),
+            id: MessageId::new(FolderId::new("INBOX"), "1"),
             account_id: AccountId::new("a"),
             folder_id: FolderId::new("INBOX"),
             subject: Some("Hello".into()),
@@ -322,11 +322,11 @@ mod tests {
 
     fn loaded_plain(text: &str) -> LoadedMessage {
         LoadedMessage {
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             folder_id: FolderId::new("INBOX"),
             parts: vec![MessagePart {
                 id: MessagePartId::new("p1"),
-                envelope_id: MessageId::new("1"),
+                envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
                 path: vec!["1".into()],
                 kind: PartKind::TextPlain,
                 content_type: "text/plain".into(),
@@ -348,11 +348,11 @@ mod tests {
 
     fn loaded_html_only(html: &str) -> LoadedMessage {
         LoadedMessage {
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
             folder_id: FolderId::new("INBOX"),
             parts: vec![MessagePart {
                 id: MessagePartId::new("h1"),
-                envelope_id: MessageId::new("1"),
+                envelope_id: MessageId::new(FolderId::new("INBOX"), "1"),
                 path: vec!["1".into()],
                 kind: PartKind::TextHtml,
                 content_type: "text/html".into(),

--- a/crates/mailiner-core/src/connector.rs
+++ b/crates/mailiner-core/src/connector.rs
@@ -116,7 +116,7 @@ fn mock_envelopes(folder_id: &FolderId, range: Range<usize>) -> Result<Vec<Envel
     // Arrival: index 0 is newest (`test-message-100`).
     for i in start..end {
         let n = total - i;
-        let message_id = MessageId::new(format!("test-message-{n}"));
+        let message_id = MessageId::new(folder_id.clone(), format!("test-message-{n}"));
         envelopes.push(Envelope {
             id: message_id.clone(),
             account_id: AccountId::new("mock-account-1"),
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn message_part_section_text() {
-        let p = mock_text_part(MessageId::new("1"), "p1", "hi");
+        let p = mock_text_part(MessageId::new(FolderId::new("inbox"), "1"), "p1", "hi");
         assert_eq!(p.section(), "TEXT");
         assert!(p.should_prefetch());
     }
@@ -443,13 +443,13 @@ mod tests {
     #[test]
     fn loaded_message_filters() {
         let mut parts = vec![
-            mock_text_part(MessageId::new("1"), "a", "hi"),
-            mock_text_part(MessageId::new("1"), "b", "att"),
+            mock_text_part(MessageId::new(FolderId::new("inbox"), "1"), "a", "hi"),
+            mock_text_part(MessageId::new(FolderId::new("inbox"), "1"), "b", "att"),
         ];
         parts[1].is_attachment = true;
         parts[1].is_hidden = false;
         let loaded = LoadedMessage {
-            envelope_id: MessageId::new("1"),
+            envelope_id: MessageId::new(FolderId::new("inbox"), "1"),
             folder_id: FolderId::new("inbox"),
             parts,
         };

--- a/crates/mailiner-core/src/ids.rs
+++ b/crates/mailiner-core/src/ids.rs
@@ -7,8 +7,16 @@ pub struct AccountId(String);
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FolderId(String);
 
+/// Folder-scoped IMAP UID. The same numeric UID in two mailboxes is two ids.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct MessageId(String);
+pub struct MessageId {
+    folder_id: FolderId,
+    uid: String,
+}
+
+/// [`MessageId::try_new`] rejected an empty folder id or UID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptyMessageId;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MessagePartId(String);
@@ -34,12 +42,34 @@ impl FolderId {
 }
 
 impl MessageId {
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    /// Build an id. Folder and UID must both be non-empty.
+    pub fn try_new(folder_id: FolderId, uid: impl Into<String>) -> Result<Self, EmptyMessageId> {
+        let uid = uid.into();
+        if folder_id.as_str().is_empty() || uid.is_empty() {
+            Err(EmptyMessageId)
+        } else {
+            Ok(Self { folder_id, uid })
+        }
     }
 
-    pub fn as_str(&self) -> &str {
-        &self.0
+    /// Build an id. Panics if folder or UID is empty.
+    pub fn new(folder_id: FolderId, uid: impl Into<String>) -> Self {
+        Self::try_new(folder_id, uid).expect("MessageId folder and uid must be non-empty")
+    }
+
+    pub fn folder_id(&self) -> &FolderId {
+        &self.folder_id
+    }
+
+    /// IMAP UID atom (FETCH / STORE / MOVE). Not unique across folders.
+    pub fn as_uid(&self) -> &str {
+        &self.uid
+    }
+}
+
+impl AsRef<FolderId> for MessageId {
+    fn as_ref(&self) -> &FolderId {
+        &self.folder_id
     }
 }
 
@@ -67,12 +97,40 @@ impl fmt::Display for FolderId {
 
 impl fmt::Display for MessageId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        // Unit separator: mailbox names may contain `#`, `/`, `:`.
+        write!(f, "{}\u{1f}{}", self.folder_id.as_str(), self.uid)
     }
 }
 
 impl fmt::Display for MessagePartId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_uid_different_folders_are_distinct() {
+        let inbox = MessageId::new(FolderId::new("INBOX"), "12");
+        let sent = MessageId::new(FolderId::new("Sent"), "12");
+        assert_ne!(inbox, sent);
+        assert_eq!(inbox.as_uid(), "12");
+        assert_eq!(sent.as_uid(), "12");
+        assert_eq!(inbox.folder_id().as_str(), "INBOX");
+    }
+
+    #[test]
+    fn rejects_empty_folder_or_uid() {
+        assert_eq!(
+            MessageId::try_new(FolderId::new(""), "1"),
+            Err(EmptyMessageId)
+        );
+        assert_eq!(
+            MessageId::try_new(FolderId::new("INBOX"), ""),
+            Err(EmptyMessageId)
+        );
     }
 }

--- a/crates/mailiner-core/src/ids.rs
+++ b/crates/mailiner-core/src/ids.rs
@@ -97,8 +97,9 @@ impl fmt::Display for FolderId {
 
 impl fmt::Display for MessageId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Unit separator: mailbox names may contain `#`, `/`, `:`.
-        write!(f, "{}\u{1f}{}", self.folder_id.as_str(), self.uid)
+        // Length-prefixed folder so a U+001F in either part cannot collide.
+        let folder = self.folder_id.as_str();
+        write!(f, "{}:{}\u{1f}{}", folder.len(), folder, self.uid)
     }
 }
 
@@ -132,5 +133,13 @@ mod tests {
             MessageId::try_new(FolderId::new("INBOX"), ""),
             Err(EmptyMessageId)
         );
+    }
+
+    #[test]
+    fn display_does_not_collide_when_folder_contains_separator() {
+        let a = MessageId::new(FolderId::new("IN\u{1f}BOX"), "12");
+        let b = MessageId::new(FolderId::new("IN"), "BOX\u{1f}12");
+        assert_ne!(a.to_string(), b.to_string());
+        assert_eq!(a.to_string(), format!("6:IN\u{1f}BOX\u{1f}12"));
     }
 }

--- a/crates/mailiner-core/src/lib.rs
+++ b/crates/mailiner-core/src/lib.rs
@@ -10,7 +10,7 @@ pub use connector::{
     mock_multipart_structure, mock_text_part, EmailConnector, MockConnector, PartStream,
 };
 pub use error::{MailinerError, Result};
-pub use ids::{AccountId, FolderId, MessageId, MessagePartId};
+pub use ids::{AccountId, EmptyMessageId, FolderId, MessageId, MessagePartId};
 pub use models::{
     Account, EmailAddr, EmailAddress, Envelope, EnvelopeFlag, Folder, FolderCounts,
     FolderListState, Group, LoadedMessage, MailboxRole, MessageContent, MessagePart, MessageSort,

--- a/crates/mailiner-imap-connector/src/lib.rs
+++ b/crates/mailiner-imap-connector/src/lib.rs
@@ -279,7 +279,7 @@ where
             .ok_or::<MailinerError>(
                 ImapError::InvalidData("Failed to parse headers".to_string()).into(),
             )?;
-        let mid = MessageId::new(uid.to_string());
+        let mid = MessageId::new(folder_id.clone(), uid.to_string());
         let has_attachments = if let Some(bs) = fetch.bodystructure() {
             let part = bodystructure::convert_body_structure(bs);
             let has = bodystructure::structure_has_attachments(&part);
@@ -360,7 +360,7 @@ where
         if let Some(uids) = idx.uids.as_mut() {
             let gone: std::collections::HashSet<u32> = message_ids
                 .iter()
-                .filter_map(|id| id.as_str().parse().ok())
+                .filter_map(|id| id.as_uid().parse().ok())
                 .collect();
             uids.retain(|u| !gone.contains(u));
             idx.total = uids.len();
@@ -588,7 +588,7 @@ fn uid_set(ids: &[MessageId]) -> Result<String, ImapError> {
     }
     Ok(ids
         .iter()
-        .map(MessageId::as_str)
+        .map(MessageId::as_uid)
         .collect::<Vec<_>>()
         .join(","))
 }
@@ -597,14 +597,16 @@ fn quote_mailbox(name: &str) -> String {
     format!("\"{}\"", name.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
-fn expand_uid_set(members: &[imap_proto::UidSetMember]) -> Vec<MessageId> {
+fn expand_uid_set(folder_id: &FolderId, members: &[imap_proto::UidSetMember]) -> Vec<MessageId> {
     let mut out = Vec::new();
     for member in members {
         match member {
-            imap_proto::UidSetMember::Uid(u) => out.push(MessageId::new(u.to_string())),
+            imap_proto::UidSetMember::Uid(u) => {
+                out.push(MessageId::new(folder_id.clone(), u.to_string()))
+            }
             imap_proto::UidSetMember::UidRange(range) => {
                 for u in *range.start()..=*range.end() {
-                    out.push(MessageId::new(u.to_string()));
+                    out.push(MessageId::new(folder_id.clone(), u.to_string()));
                 }
             }
         }
@@ -612,9 +614,14 @@ fn expand_uid_set(members: &[imap_proto::UidSetMember]) -> Vec<MessageId> {
     out
 }
 
-fn copyuid_dest(code: &Option<imap_proto::ResponseCode<'_>>) -> Option<Vec<MessageId>> {
+fn copyuid_dest(
+    folder_id: &FolderId,
+    code: &Option<imap_proto::ResponseCode<'_>>,
+) -> Option<Vec<MessageId>> {
     match code {
-        Some(imap_proto::ResponseCode::CopyUid(_, _, dest)) => Some(expand_uid_set(dest)),
+        Some(imap_proto::ResponseCode::CopyUid(_, _, dest)) => {
+            Some(expand_uid_set(folder_id, dest))
+        }
         _ => None,
     }
 }
@@ -622,6 +629,7 @@ fn copyuid_dest(code: &Option<imap_proto::ResponseCode<'_>>) -> Option<Vec<Messa
 /// Run a tagged command and collect destination UIDs from COPYUID.
 async fn run_copyuid_command<S>(
     session: &mut Session<TlsStream<S>>,
+    dest_folder_id: &FolderId,
     command: &str,
 ) -> MailinerResult<Vec<MessageId>>
 where
@@ -640,7 +648,7 @@ where
             .ok_or_else(|| ImapError::Imap("IMAP connection closed".into()))?;
         match resp.parsed() {
             imap_proto::Response::Data { code, .. } => {
-                if let Some(uids) = copyuid_dest(code) {
+                if let Some(uids) = copyuid_dest(dest_folder_id, code) {
                     dest_uids = uids;
                 }
             }
@@ -650,7 +658,7 @@ where
                 code,
                 information,
             } if done_tag == &tag => {
-                if let Some(uids) = copyuid_dest(code) {
+                if let Some(uids) = copyuid_dest(dest_folder_id, code) {
                     dest_uids = uids;
                 }
                 return match status {
@@ -982,7 +990,7 @@ where
             if let Some(order) = uid_order {
                 let mut by_uid: HashMap<u32, Envelope> = envelopes
                     .into_iter()
-                    .filter_map(|e| e.id.as_str().parse::<u32>().ok().map(|u| (u, e)))
+                    .filter_map(|e| e.id.as_uid().parse::<u32>().ok().map(|u| (u, e)))
                     .collect();
                 envelopes = order
                     .into_iter()
@@ -1059,7 +1067,7 @@ where
         let mut unread = index.unread.unwrap_or(0);
         let mut moves = Vec::new();
         for id in message_ids {
-            let Ok(uid) = id.as_str().parse::<u32>() else {
+            let Ok(uid) = id.as_uid().parse::<u32>() else {
                 continue;
             };
             if let Some(mv) = sort::move_uid_for_seen_flag(uids, &mut unread, uid, now_read) {
@@ -1091,7 +1099,8 @@ where
             .await
             .map_err(|e| ImapError::Imap(format!("Failed to select folder: {e}")))?;
 
-        match run_copyuid_command(session, &format!("UID MOVE {uids} {dest}")).await {
+        match run_copyuid_command(session, dest_folder_id, &format!("UID MOVE {uids} {dest}")).await
+        {
             Ok(dest_uids) => {
                 drop(imap);
                 self.forget_messages(folder_id, message_ids).await;
@@ -1101,7 +1110,9 @@ where
         }
 
         // RFC 6851 fallback: COPY + \Deleted + EXPUNGE.
-        let dest_uids = run_copyuid_command(session, &format!("UID COPY {uids} {dest}")).await?;
+        let dest_uids =
+            run_copyuid_command(session, dest_folder_id, &format!("UID COPY {uids} {dest}"))
+                .await?;
         if let Err(e) = delete_selected_uids(session, &uids).await {
             return Err(MailinerError::PartialMove {
                 message: e.to_string(),
@@ -1161,7 +1172,7 @@ where
                 .map_err(|e| ImapError::Imap(format!("Failed to select folder: {}", e)))?;
 
             let mut fetch = session
-                .uid_fetch(message_id.as_str(), "(BODYSTRUCTURE)")
+                .uid_fetch(message_id.as_uid(), "(BODYSTRUCTURE)")
                 .await
                 .map_err(|e| ImapError::Imap(format!("Failed to fetch BODYSTRUCTURE: {}", e)))?;
 
@@ -1208,7 +1219,7 @@ where
             .map_err(|e| ImapError::Imap(format!("Failed to select folder: {}", e)))?;
 
         let mut fetch = session
-            .uid_fetch(message_id.as_str(), &query)
+            .uid_fetch(message_id.as_uid(), &query)
             .await
             .map_err(|e| ImapError::Imap(format!("Failed to fetch parts: {}", e)))?;
 
@@ -1258,7 +1269,7 @@ where
 
         let imap = Arc::clone(&self.imap);
         let folder_id = folder_id.as_str().to_string();
-        let message_id = message_id.as_str().to_string();
+        let message_id = message_id.as_uid().to_string();
         let section = section.to_string();
         let chunk_size = Self::STREAM_CHUNK;
         let max_download = Self::MAX_DOWNLOAD;
@@ -1441,7 +1452,11 @@ mod tests {
 
     #[test]
     fn uid_set_joins() {
-        let ids = [MessageId::new("12"), MessageId::new("44")];
+        let folder = FolderId::new("INBOX");
+        let ids = [
+            MessageId::new(folder.clone(), "12"),
+            MessageId::new(folder, "44"),
+        ];
         assert_eq!(uid_set(&ids).unwrap(), "12,44");
         assert!(uid_set(&[]).is_err());
     }
@@ -1455,11 +1470,16 @@ mod tests {
 
     #[test]
     fn expand_uid_range() {
-        let ids = expand_uid_set(&[
-            imap_proto::UidSetMember::Uid(12),
-            imap_proto::UidSetMember::UidRange(20..=22),
-        ]);
-        let raw: Vec<_> = ids.iter().map(MessageId::as_str).collect();
+        let folder = FolderId::new("Sent");
+        let ids = expand_uid_set(
+            &folder,
+            &[
+                imap_proto::UidSetMember::Uid(12),
+                imap_proto::UidSetMember::UidRange(20..=22),
+            ],
+        );
+        let raw: Vec<_> = ids.iter().map(MessageId::as_uid).collect();
         assert_eq!(raw, ["12", "20", "21", "22"]);
+        assert!(ids.iter().all(|id| id.folder_id() == &folder));
     }
 }

--- a/crates/mailiner-imap-connector/src/lib.rs
+++ b/crates/mailiner-imap-connector/src/lib.rs
@@ -582,10 +582,20 @@ fn imap_flag_atom(flag: EnvelopeFlag) -> &'static str {
     }
 }
 
-fn uid_set(ids: &[MessageId]) -> Result<String, ImapError> {
+fn require_folder(folder_id: &FolderId, ids: &[MessageId]) -> Result<(), ImapError> {
+    if ids.iter().any(|id| id.folder_id() != folder_id) {
+        return Err(ImapError::InvalidData(
+            "message id is not in the selected folder".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn uid_set(folder_id: &FolderId, ids: &[MessageId]) -> Result<String, ImapError> {
     if ids.is_empty() {
         return Err(ImapError::InvalidData("No message ids".into()));
     }
+    require_folder(folder_id, ids)?;
     Ok(ids
         .iter()
         .map(MessageId::as_uid)
@@ -1025,7 +1035,7 @@ where
         if message_ids.is_empty() || flags.is_empty() {
             return Ok(());
         }
-        let uids = uid_set(message_ids)?;
+        let uids = uid_set(folder_id, message_ids)?;
         let mut imap = self.imap.lock().await;
         let ImapSession::Authenticated(session) = &mut *imap else {
             return Err(ImapError::NotAuthenticated.into());
@@ -1087,7 +1097,7 @@ where
         if message_ids.is_empty() || folder_id == dest_folder_id {
             return Ok(message_ids.to_vec());
         }
-        let uids = uid_set(message_ids)?;
+        let uids = uid_set(folder_id, message_ids)?;
         let dest = quote_mailbox(dest_folder_id.as_str());
         let mut imap = self.imap.lock().await;
         let ImapSession::Authenticated(session) = &mut *imap else {
@@ -1132,7 +1142,7 @@ where
         if message_ids.is_empty() {
             return Ok(());
         }
-        let uids = uid_set(message_ids)?;
+        let uids = uid_set(folder_id, message_ids)?;
         let mut imap = self.imap.lock().await;
         let ImapSession::Authenticated(session) = &mut *imap else {
             return Err(ImapError::NotAuthenticated.into());
@@ -1153,6 +1163,7 @@ where
         folder_id: &FolderId,
         message_id: &MessageId,
     ) -> MailinerResult<BodyPart> {
+        require_folder(folder_id, std::slice::from_ref(message_id))?;
         {
             let cache = self.structure_cache.lock().await;
             if let Some(part) = cache.get(&(folder_id.clone(), message_id.clone())) {
@@ -1201,6 +1212,7 @@ where
         message_id: &MessageId,
         sections: &[String],
     ) -> MailinerResult<HashMap<String, Vec<u8>>> {
+        require_folder(folder_id, std::slice::from_ref(message_id))?;
         if sections.is_empty() {
             return Ok(HashMap::new());
         }
@@ -1243,6 +1255,7 @@ where
         message_id: &MessageId,
         section: &str,
     ) -> MailinerResult<PartStream> {
+        require_folder(folder_id, std::slice::from_ref(message_id))?;
         // Fail fast if not authenticated (before returning a stream that would error later).
         {
             let imap = self.imap.lock().await;
@@ -1455,10 +1468,15 @@ mod tests {
         let folder = FolderId::new("INBOX");
         let ids = [
             MessageId::new(folder.clone(), "12"),
-            MessageId::new(folder, "44"),
+            MessageId::new(folder.clone(), "44"),
         ];
-        assert_eq!(uid_set(&ids).unwrap(), "12,44");
-        assert!(uid_set(&[]).is_err());
+        assert_eq!(uid_set(&folder, &ids).unwrap(), "12,44");
+        assert!(uid_set(&folder, &[]).is_err());
+        let mixed = [
+            MessageId::new(FolderId::new("INBOX"), "12"),
+            MessageId::new(FolderId::new("Sent"), "44"),
+        ];
+        assert!(uid_set(&FolderId::new("INBOX"), &mixed).is_err());
     }
 
     #[test]

--- a/crates/mailiner-mime/src/parser/mod.rs
+++ b/crates/mailiner-mime/src/parser/mod.rs
@@ -198,12 +198,13 @@ mod tests {
     use super::*;
     use mailiner_core::body::ContentDisposition;
     use mailiner_core::connector::mock_multipart_structure;
+    use mailiner_core::ids::FolderId;
 
     #[test]
     fn alternative_prefers_html() {
         let root = mock_multipart_structure();
         let parser = MessageParser::with_defaults();
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         // Should have HTML (from alternative) + PDF attachment
         assert!(
             parts.iter().any(|p| p.kind == PartKind::TextHtml),
@@ -238,7 +239,7 @@ mod tests {
             ..Default::default()
         };
         let parser = MessageParser::with_defaults();
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].section(), "TEXT");
         assert_eq!(parts[0].kind, PartKind::TextPlain);
@@ -272,7 +273,7 @@ mod tests {
             ..Default::default()
         };
         let parser = MessageParser::with_defaults();
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         let img = parts.iter().find(|p| p.kind == PartKind::Image).unwrap();
         assert!(img.is_hidden);
         assert!(img.is_attachment);
@@ -290,7 +291,7 @@ mod tests {
             ..Default::default()
         };
         let parser = MessageParser::with_defaults();
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         assert_eq!(parts.len(), 1);
         assert!(!parts[0].is_attachment);
         assert_eq!(parts[0].kind, PartKind::TextPlain);
@@ -306,7 +307,7 @@ mod tests {
             ..Default::default()
         };
         let parser = MessageParser::with_defaults();
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].kind, PartKind::Attachment);
         assert!(parts[0].is_attachment);
@@ -327,7 +328,7 @@ mod tests {
         };
         let parser = MessageParser::with_defaults();
         // message/rfc822 is not text/image/multipart — falls through to attachment
-        let parts = parser.parse(&MessageId::new("1"), &root);
+        let parts = parser.parse(&MessageId::new(FolderId::new("INBOX"), "1"), &root);
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].kind, PartKind::Attachment);
     }


### PR DESCRIPTION
IMAP UIDs are unique per mailbox. Core `MessageId` was a bare UID string, so Inbox `12` and Sent `12` collided. The app kept a second `MessageId` and string-roundtripped the core type.

## Change
- `MessageId` is now `(folder_id, uid)`
- Empty folder or UID is rejected (`try_new` / `new`)
- IMAP commands use `as_uid()`; `COPYUID` dest ids are scoped to the destination folder
- App re-exports the core type; `From<Envelope>` keeps `envelope.id` instead of `to_string()`

This is the identity-model cleanup called out in `docs/review.md` item 1. Own PR, no feature work mixed in.

Closes #98

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `MessageId` folder-scoped so the same IMAP UID in different mailboxes no longer collides.

- `MessageId` is now a folder ID plus UID; empty folder or UID values are rejected.
- IMAP commands use `as_uid()` and reject ids that aren't in the selected folder; COPYUID destination IDs are scoped to the destination folder.
- `Display` is length-prefixed so a separator character in a folder name can't create a collision.
- The app re-exports the core type and drops its own parallel `MessageId`, which string-roundtripped the core type.
- `MessageId::new` now takes the folder ID first and panics on an empty folder or UID.

Closes #98.

<sup>Written for commit 322079c656b07e5e440c1129d89a4ecfde15761c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mailiner-net/mailiner-rs/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

