### PR TITLE
fix(ui): do not auto-mark read during multi-select

### DIFF
--- a/crates/mailiner-app/src/core_event.rs
+++ b/crates/mailiner-app/src/core_event.rs
@@ -1095,7 +1095,7 @@ async fn handle_select_list_click(
 ) {
     if extend {
         apply_index_range_selection(manager, ctx, index).await;
-        handle_select_message(manager, ctx, message_id, true, false).await;
+        handle_select_message(manager, ctx, message_id, false, false).await;
         return;
     }
     if toggle {
@@ -1105,7 +1105,7 @@ async fn handle_select_list_click(
         let Some(focus) = ctx.selection.read().focus().cloned() else {
             return;
         };
-        handle_select_message(manager, ctx, focus, true, false).await;
+        handle_select_message(manager, ctx, focus, false, false).await;
         return;
     }
     handle_select_message(manager, ctx, message_id, true, true).await;
@@ -1158,7 +1158,14 @@ async fn select_list_index(
     let Some(message_id) = ctx.messages.read().get(index).map(|m| m.id.clone()) else {
         return;
     };
-    handle_select_message(manager, ctx, message_id, true, replace_selection).await;
+    handle_select_message(
+        manager,
+        ctx,
+        message_id,
+        replace_selection,
+        replace_selection,
+    )
+    .await;
 }
 
 async fn select_after_removed_row(
@@ -1238,7 +1245,8 @@ async fn handle_select_message(
                 .read()
                 .find(|m| m.id == message_id)
                 .is_some_and(|m| !m.is_read);
-            if was_unread && auto_mark_read {
+            let is_multi = ctx.selection.read().is_multi();
+            if was_unread && crate::selection::should_auto_mark_read(auto_mark_read, is_multi) {
                 apply_read_flag(ctx, std::slice::from_ref(&message_id), true);
                 if let Err(e) = connector
                     .update_envelope_flags(

--- a/crates/mailiner-app/src/selection.rs
+++ b/crates/mailiner-app/src/selection.rs
@@ -27,6 +27,11 @@ impl MessageSelection {
         self.ids.len()
     }
 
+    /// True when more than one row is selected (batch-action, not a read).
+    pub fn is_multi(&self) -> bool {
+        self.ids.len() > 1
+    }
+
     pub fn contains(&self, id: &MessageId) -> bool {
         self.ids.contains(id)
     }
@@ -124,6 +129,15 @@ impl MessageSelection {
     }
 }
 
+/// Auto-mark `\Seen` only when opening a single message.
+///
+/// `requested` is the caller's intent (plain click / arrow, or Unread-first
+/// mailbox-open which already passes `false`). Multi-select is a batch-action
+/// gesture and must not consume unread.
+pub fn should_auto_mark_read(requested: bool, is_multi: bool) -> bool {
+    requested && !is_multi
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,8 +185,25 @@ mod tests {
         s.replace(id("a"), Some(2));
         s.set_range([id("a"), id("b"), id("c")], id("c"), Some(4));
         assert_eq!(s.len(), 3);
+        assert!(s.is_multi());
         assert_eq!(s.focus(), Some(&id("c")));
         assert_eq!(s.anchor_index(), Some(2));
         assert_eq!(s.focus_at_index(), Some(4));
+    }
+
+    #[test]
+    fn single_select_is_not_multi() {
+        let mut s = MessageSelection::default();
+        assert!(!s.is_multi());
+        s.replace(id("a"), Some(0));
+        assert!(!s.is_multi());
+    }
+
+    #[test]
+    fn auto_mark_only_when_opening_one_message() {
+        assert!(should_auto_mark_read(true, false));
+        assert!(!should_auto_mark_read(true, true));
+        assert!(!should_auto_mark_read(false, false));
+        assert!(!should_auto_mark_read(false, true));
     }
 }


### PR DESCRIPTION
Shift/Ctrl+click and Shift+arrow are batch-action gestures, not a read. Auto-marking the focused row as `\Seen` was surprising and, on Unread-first sort, relocated the row mid-range.

## Change
- Extend/toggle list clicks and Shift+arrow pass `auto_mark_read: false`
- `handle_select_message` also skips auto-mark when `selection.is_multi()`
- Plain click / arrow still auto-mark a single opened message (Unread-first mailbox-open still skips, as before)
- Header **Mark read / Mark unread** is unchanged and still applies to the whole selection

## Test
- Unit: `should_auto_mark_read` / `is_multi` in `selection.rs`
- Manual: Shift+click, Ctrl+click, and Shift+↓ on unread Inbox rows left them unread and did not move the Unread-first list

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops multi-select gestures from auto-marking messages as read, so Shift/Ctrl+click and Shift+arrow no longer relocate the focused row in Unread-first sort.

- Extend/toggle list clicks and Shift+arrow now pass `auto_mark_read: false`.
- `handle_select_message` skips the auto-mark when more than one row is selected.
- Plain click and arrow still auto-mark a single opened message; Unread-first mailbox-open is unchanged.
- Header Mark read/Mark unread is unchanged and still applies to the whole selection.

<sup>Written for commit a845a2524cdc13e3b970af77988a1a9f23c3fed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mailiner-net/mailiner-rs/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

