### PR TITLE
feat(app): cache mailbox tree and message-list prefixes in localStorage

### DIFF
--- a/crates/mailiner-app/src/components/virtual_scroll.rs
+++ b/crates/mailiner-app/src/components/virtual_scroll.rs
@@ -665,6 +665,17 @@ mod tests {
     }
 
     #[test]
+    fn cached_prefix_still_reports_holes_for_incremental_fetch() {
+        // Mail cache stores only a contiguous head; virtual scroll must keep
+        // requesting the unloaded tail (and any interior holes).
+        let mut list = SparseList::new(40);
+        list.insert_batch(0, vec!["m0", "m1", "m2", "m3", "m4"]);
+        assert!(list.missing_ranges(0, 5).is_empty());
+        assert_eq!(list.missing_ranges(0, 12), vec![5..12]);
+        assert_eq!(list.missing_ranges(20, 25), vec![20..25]);
+    }
+
+    #[test]
     fn sparse_list_no_dense_allocation() {
         let mut list = SparseList::new(60_000);
         list.insert(0, 1);

--- a/crates/mailiner-app/src/connection.rs
+++ b/crates/mailiner-app/src/connection.rs
@@ -25,6 +25,7 @@ use mailiner_imap_connector::ImapConnector;
 use crate::account_config::AccountConfig;
 use crate::account_store::AccountStore;
 use crate::context::AppContext;
+use crate::mail_cache::MailCache;
 use crate::websocket_stream::WebSocketStream;
 
 /// Overall connect budget: WS open + TLS + LOGIN (wall clock).
@@ -219,21 +220,27 @@ pub struct AccountConnectionManager {
     /// See module docs: v1 serializes connects; generation is defensive / future-proof.
     connect_generation: HashMap<AccountId, u64>,
     store: Rc<dyn AccountStore>,
+    cache: Rc<dyn MailCache>,
 }
 
 impl AccountConnectionManager {
-    pub fn new(store: Rc<dyn AccountStore>) -> Self {
+    pub fn new(store: Rc<dyn AccountStore>, cache: Rc<dyn MailCache>) -> Self {
         Self {
             connectors: HashMap::new(),
             configs: HashMap::new(),
             memory_only: HashSet::new(),
             connect_generation: HashMap::new(),
             store,
+            cache,
         }
     }
 
     pub fn store(&self) -> &Rc<dyn AccountStore> {
         &self.store
+    }
+
+    pub fn cache(&self) -> &dyn MailCache {
+        self.cache.as_ref()
     }
 
     pub fn get(&self, account_id: &AccountId) -> Option<&ImapConnector<WebSocketStream>> {

--- a/crates/mailiner-app/src/core_event.rs
+++ b/crates/mailiner-app/src/core_event.rs
@@ -527,9 +527,10 @@ async fn handle_select_account(
     account_id: AccountId,
 ) {
     ctx.selected_account.set(Some(account_id.clone()));
-    if !hydrate_account_into(manager.cache(), ctx, &account_id).await {
-        clear_mailbox_ui(ctx);
-    }
+    // Drop the previous account's selection / body before hydrate so a
+    // cache hit cannot leave the old message view painted over the new tree.
+    clear_mailbox_ui(ctx);
+    hydrate_account_into(manager.cache(), ctx, &account_id).await;
 
     let Some(config) = manager.resolve_config(&account_id).await else {
         error!("SelectAccount: unknown account {}", account_id);
@@ -970,7 +971,7 @@ fn apply_cached_message_list(ctx: &mut AppContext, cached: &CachedMessageList) {
 }
 
 /// `true` when a folder tree was applied from cache.
-async fn hydrate_account_into(
+pub(crate) async fn hydrate_account_into(
     cache: &dyn MailCache,
     ctx: &mut AppContext,
     account_id: &AccountId,
@@ -1004,10 +1005,14 @@ async fn persist_folder_tree(cache: &dyn MailCache, ctx: &AppContext, account_id
     }
 }
 
-async fn persist_selected_messages(cache: &dyn MailCache, ctx: &AppContext) {
-    let Some(account_id) = ctx.selected_account.read().clone() else {
+async fn persist_selected_messages(
+    cache: &dyn MailCache,
+    ctx: &AppContext,
+    account_id: &AccountId,
+) {
+    if ctx.selected_account.read().as_ref() != Some(account_id) {
         return;
-    };
+    }
     let Some(mailbox_id) = ctx.selected_mailbox.read().clone() else {
         return;
     };
@@ -1028,9 +1033,22 @@ async fn persist_selected_messages(cache: &dyn MailCache, ctx: &AppContext) {
         return;
     }
     let snapshot = CachedMessageList::from_prefix(&mailbox_id, sort, total, unread, prefix);
-    if let Err(e) = cache.save_messages(&account_id, &snapshot).await {
+    if let Err(e) = cache.save_messages(account_id, &snapshot).await {
         warn!("mail cache save messages failed: {e}");
     }
+}
+
+fn contiguous_loaded_prefix_len<T: Clone>(list: &SparseList<T>) -> usize {
+    let cap = list.total_count();
+    let mut n = 0;
+    while n < cap && list.has_item(n) {
+        n += 1;
+    }
+    n
+}
+
+fn selected_account_is(ctx: &AppContext, account_id: &AccountId) -> bool {
+    ctx.selected_account.read().as_ref() == Some(account_id)
 }
 
 async fn invalidate_mailbox_messages(
@@ -1122,7 +1140,9 @@ async fn handle_select_mailbox(
             } else {
                 Ok(Vec::new())
             };
-            if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id) {
+            if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id)
+                || !selected_account_is(ctx, &account_id)
+            {
                 return;
             }
             match live {
@@ -1132,7 +1152,7 @@ async fn handle_select_mailbox(
                     list.insert_batch(0, batch);
                     ctx.messages.set(list);
                     ctx.messages_loading.set(false);
-                    persist_selected_messages(manager.cache(), ctx).await;
+                    persist_selected_messages(manager.cache(), ctx, &account_id).await;
                     persist_folder_tree(manager.cache(), ctx, &account_id).await;
                 }
                 Err(e) => {
@@ -1142,8 +1162,16 @@ async fn handle_select_mailbox(
                         e
                     );
                     ctx.messages_loading.set(false);
-                    if ctx.messages.read().total_count() == 0 {
-                        ctx.messages.set(SparseList::new(state.total));
+                    {
+                        let mut list = ctx.messages.write();
+                        if list.cached_count() == 0 {
+                            *list = SparseList::new(state.total);
+                        } else if list.total_count() != state.total {
+                            list.set_total_count(state.total);
+                        }
+                    }
+                    if ctx.messages.read().cached_count() > 0 {
+                        persist_selected_messages(manager.cache(), ctx, &account_id).await;
                     }
                 }
             }
@@ -1226,13 +1254,18 @@ async fn handle_fetch_message_range(
         .await
     {
         Ok(envelopes) => {
-            if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id) {
+            if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id)
+                || !selected_account_is(ctx, &account_id)
+            {
                 return;
             }
+            let prefix_before = contiguous_loaded_prefix_len(&ctx.messages.read());
             let batch: Vec<_> = envelopes.into_iter().map(|e| Arc::new(e.into())).collect();
             ctx.messages.write().insert_batch(range.start, batch);
-            // Extending the contiguous head updates the persisted prefix.
-            persist_selected_messages(manager.cache(), ctx).await;
+            // Only rewrite localStorage when the contiguous cached prefix grew.
+            if contiguous_loaded_prefix_len(&ctx.messages.read()) > prefix_before {
+                persist_selected_messages(manager.cache(), ctx, &account_id).await;
+            }
         }
         Err(e) => {
             error!(
@@ -1445,9 +1478,9 @@ async fn handle_select_message(
                         true,
                     )
                     .await;
-                    persist_selected_messages(manager.cache(), ctx).await;
                     let account_id = ctx.selected_account.read().clone();
                     if let Some(account_id) = account_id {
+                        persist_selected_messages(manager.cache(), ctx, &account_id).await;
                         persist_folder_tree(manager.cache(), ctx, &account_id).await;
                     }
                 }
@@ -1681,7 +1714,7 @@ async fn handle_mark_read(
         return;
     }
     relocate_unread_sort_rows(connector, ctx, &message_ids, is_read).await;
-    persist_selected_messages(manager.cache(), ctx).await;
+    persist_selected_messages(manager.cache(), ctx, &account_id).await;
     persist_folder_tree(manager.cache(), ctx, &account_id).await;
 }
 
@@ -1758,6 +1791,7 @@ async fn handle_move_messages(
                 ctx.show_toast(ToastAction::moved(
                     dest_label,
                     MoveUndo {
+                        account_id: account_id.clone(),
                         from: dest_mailbox_id.clone(),
                         to: mailbox_id,
                         dest_ids,
@@ -1768,7 +1802,7 @@ async fn handle_move_messages(
                 ctx.show_toast(ToastAction::info(format!("Moved to {dest_label}")));
             }
             select_after_removed_row(manager, ctx, removed_sel).await;
-            persist_selected_messages(manager.cache(), ctx).await;
+            persist_selected_messages(manager.cache(), ctx, &account_id).await;
             persist_folder_tree(manager.cache(), ctx, &account_id).await;
             invalidate_mailbox_messages(manager.cache(), &account_id, &dest_mailbox_id).await;
         }
@@ -1821,7 +1855,7 @@ async fn handle_move_to_trash(
     let core_ids = core_message_ids(&message_ids);
 
     if source_is_trash || trash_id.as_ref() == Some(&mailbox_id) {
-        schedule_permanent_delete(manager, ctx, mailbox_id, &message_ids).await;
+        schedule_permanent_delete(manager, ctx, account_id, mailbox_id, &message_ids).await;
         return;
     }
 
@@ -1844,6 +1878,7 @@ async fn handle_move_to_trash(
             let dest_ids = dest_uids;
             if dest_ids.len() == snapshots.len() && !dest_ids.is_empty() {
                 ctx.show_toast(ToastAction::trashed(MoveUndo {
+                    account_id: account_id.clone(),
                     from: trash_id.clone(),
                     to: mailbox_id,
                     dest_ids,
@@ -1853,7 +1888,7 @@ async fn handle_move_to_trash(
                 ctx.show_toast(ToastAction::info("Moved to Trash"));
             }
             select_after_removed_row(manager, ctx, removed_sel).await;
-            persist_selected_messages(manager.cache(), ctx).await;
+            persist_selected_messages(manager.cache(), ctx, &account_id).await;
             persist_folder_tree(manager.cache(), ctx, &account_id).await;
             invalidate_mailbox_messages(manager.cache(), &account_id, &trash_id).await;
         }
@@ -1893,44 +1928,53 @@ async fn handle_delete_messages(
         ctx.show_toast(ToastAction::error("Not connected"));
         return;
     }
-    schedule_permanent_delete(manager, ctx, mailbox_id, &message_ids).await;
+    schedule_permanent_delete(manager, ctx, account_id, mailbox_id, &message_ids).await;
 }
 
 async fn schedule_permanent_delete(
     manager: &AccountConnectionManager,
     ctx: &mut AppContext,
+    account_id: AccountId,
     mailbox_id: MailboxId,
     message_ids: &[MessageId],
 ) {
     let (snapshots, removed_sel) = take_messages_from_ui(ctx, message_ids);
-    ctx.show_toast(ToastAction::deleted(mailbox_id, snapshots));
+    ctx.show_toast(ToastAction::deleted(
+        account_id.clone(),
+        mailbox_id,
+        snapshots,
+    ));
     select_after_removed_row(manager, ctx, removed_sel).await;
-    let account_id = ctx.selected_account.read().clone();
-    if let Some(account_id) = account_id {
-        persist_selected_messages(manager.cache(), ctx).await;
-        persist_folder_tree(manager.cache(), ctx, &account_id).await;
-    }
+    persist_selected_messages(manager.cache(), ctx, &account_id).await;
+    persist_folder_tree(manager.cache(), ctx, &account_id).await;
 }
 
 async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, undo: UndoRequest) {
     match undo {
         UndoRequest::RestoreLocal {
+            account_id,
             mailbox_id,
             snapshots,
         } => {
+            if !selected_account_is(ctx, &account_id) {
+                ctx.show_toast(ToastAction::error(
+                    "Undo is not available after switching accounts",
+                ));
+                return;
+            }
             restore_snapshots(ctx, &mailbox_id, snapshots, None);
             ctx.show_toast(ToastAction::info("Undone"));
-            let account_id = ctx.selected_account.read().clone();
-            if let Some(account_id) = account_id {
-                persist_selected_messages(manager.cache(), ctx).await;
-                persist_folder_tree(manager.cache(), ctx, &account_id).await;
-            }
+            persist_selected_messages(manager.cache(), ctx, &account_id).await;
+            persist_folder_tree(manager.cache(), ctx, &account_id).await;
         }
         UndoRequest::ReverseMove(undo) => {
-            let Some(account_id) = ctx.selected_account.read().clone() else {
-                ctx.show_toast(ToastAction::error("No account selected"));
+            if !selected_account_is(ctx, &undo.account_id) {
+                ctx.show_toast(ToastAction::error(
+                    "Undo is not available after switching accounts",
+                ));
                 return;
-            };
+            }
+            let account_id = undo.account_id.clone();
             let Some(connector) = manager.get(&account_id) else {
                 ctx.show_toast(ToastAction::error("Not connected"));
                 return;
@@ -1951,9 +1995,15 @@ async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, u
                     let new_ids = new_uids;
                     restore_snapshots(ctx, &undo.to, undo.snapshots, Some(&new_ids));
                     ctx.show_toast(ToastAction::info("Undone"));
-                    persist_selected_messages(manager.cache(), ctx).await;
+                    persist_selected_messages(manager.cache(), ctx, &account_id).await;
                     persist_folder_tree(manager.cache(), ctx, &account_id).await;
-                    invalidate_mailbox_messages(manager.cache(), &account_id, &undo.from).await;
+                    let selected = ctx.selected_mailbox.read().clone();
+                    if selected.as_ref() != Some(&undo.from) {
+                        invalidate_mailbox_messages(manager.cache(), &account_id, &undo.from).await;
+                    }
+                    if selected.as_ref() != Some(&undo.to) {
+                        invalidate_mailbox_messages(manager.cache(), &account_id, &undo.to).await;
+                    }
                 }
                 Err(e) => {
                     error!("Failed to undo move: {}", e);
@@ -1971,12 +2021,10 @@ async fn handle_commit_dismissed(
 ) {
     match commit {
         DismissCommit::Delete {
+            account_id,
             mailbox_id,
             message_ids,
         } => {
-            let Some(account_id) = ctx.selected_account.read().clone() else {
-                return;
-            };
             let Some(connector) = manager.get(&account_id) else {
                 return;
             };

--- a/crates/mailiner-app/src/core_event.rs
+++ b/crates/mailiner-app/src/core_event.rs
@@ -23,6 +23,10 @@ use crate::connection::{
 };
 use crate::context::{AppContext, MessageViewState};
 use crate::download::{DownloadStatus, MAX_DOWNLOAD_BYTES, StreamingBlobDownload};
+use crate::mail_cache::{
+    CachedFolderTree, CachedMessageList, HydratedAccount, MailCache, contiguous_envelope_prefix,
+    hydrate_account,
+};
 use crate::mailbox::MailboxId;
 use crate::message::MessageId;
 use crate::message_loader::load_message;
@@ -189,9 +193,10 @@ pub async fn core_loop(
     mut ctx: AppContext,
     store: Rc<dyn AccountStore>,
     outbox: Rc<dyn OutboxStore>,
+    cache: Rc<dyn MailCache>,
     initial_bootstrap: InitialBootstrap,
 ) {
-    let mut manager = AccountConnectionManager::new(store);
+    let mut manager = AccountConnectionManager::new(store, cache);
     let mut smtp_generation: u64 = 0;
     let mut inflight: Option<InFlightSmtp> = None;
 
@@ -492,6 +497,10 @@ async fn handle_bootstrap(
     }
 
     ctx.selected_account.set(Some(account_id.clone()));
+    // Re-hydrate if bootstrap skipped it (e.g. later Bootstrap event).
+    if ctx.mailbox_roots.read().is_empty() {
+        hydrate_account_into(manager.cache(), ctx, &account_id).await;
+    }
     match manager
         .ensure_connected(&config, ctx, EnsureConnectedMode::Switch)
         .await
@@ -504,7 +513,10 @@ async fn handle_bootstrap(
                 "Bootstrap connect failed for {}: {} ({:?})",
                 account_id, e.message, e.kind
             );
-            clear_mailbox_ui(ctx);
+            // Keep a cache hit visible while disconnected.
+            if ctx.mailbox_roots.read().is_empty() {
+                clear_mailbox_ui(ctx);
+            }
         }
     }
 }
@@ -515,7 +527,9 @@ async fn handle_select_account(
     account_id: AccountId,
 ) {
     ctx.selected_account.set(Some(account_id.clone()));
-    clear_mailbox_ui(ctx);
+    if !hydrate_account_into(manager.cache(), ctx, &account_id).await {
+        clear_mailbox_ui(ctx);
+    }
 
     let Some(config) = manager.resolve_config(&account_id).await else {
         error!("SelectAccount: unknown account {}", account_id);
@@ -780,6 +794,9 @@ async fn handle_accounts_changed(manager: &mut AccountConnectionManager, ctx: &m
     refresh_ui_accounts(manager, ctx).await;
     crate::ui_prefs::retain_last_mailboxes(&known);
     crate::ui_prefs::retain_ack_unread(&known);
+    if let Err(e) = manager.cache().retain_accounts(&known).await {
+        warn!("mail cache retain_accounts failed: {e}");
+    }
 }
 
 /// Rebuild UI accounts from the store plus explicitly memory-only configs.
@@ -879,13 +896,15 @@ async fn list_folders_soft(
                     }
                 }
             }
+            persist_folder_tree(manager.cache(), ctx, account_id).await;
         }
         Err(e) => {
             error!("Failed to list folders for {}: {}", account_id, e);
-            ctx.mailbox_nodes.set(HashMap::new());
-            ctx.mailbox_roots.set(Vec::new());
-            // Soft-fail: keep Ready connection but surface list failure on state if desired.
-            // Leave connection Ready; empty tree is the UI signal.
+            // Keep a cached tree if we already painted one.
+            if ctx.mailbox_roots.read().is_empty() {
+                ctx.mailbox_nodes.set(HashMap::new());
+                ctx.mailbox_roots.set(Vec::new());
+            }
         }
     }
 }
@@ -919,6 +938,111 @@ fn clear_mailbox_ui(ctx: &mut AppContext) {
     ctx.mailbox_roots.set(Vec::new());
 }
 
+/// Paint a [`HydratedAccount`] onto UI signals (cache hit, no IMAP).
+pub(crate) fn apply_hydrated(ctx: &mut AppContext, hydrated: HydratedAccount) {
+    ctx.mailbox_nodes.set(hydrated.nodes);
+    ctx.mailbox_roots.set(hydrated.roots);
+    if let Some(mailbox_id) = hydrated.selected_mailbox {
+        ctx.selected_mailbox.set(Some(mailbox_id));
+    }
+    match hydrated.messages {
+        Some(msgs) => {
+            let mut list = SparseList::new(msgs.total);
+            list.insert_batch(0, msgs.prefix);
+            ctx.messages.set(list);
+            ctx.messages_loading.set(false);
+        }
+        None => {
+            if ctx.selected_mailbox.read().is_some() {
+                ctx.messages.set(SparseList::new(0));
+                ctx.messages_loading.set(true);
+            }
+        }
+    }
+}
+
+fn apply_cached_message_list(ctx: &mut AppContext, cached: &CachedMessageList) {
+    let ui = cached.to_ui_prefix();
+    let mut list = SparseList::new(ui.total);
+    list.insert_batch(0, ui.prefix);
+    ctx.messages.set(list);
+    ctx.messages_loading.set(false);
+}
+
+/// `true` when a folder tree was applied from cache.
+async fn hydrate_account_into(
+    cache: &dyn MailCache,
+    ctx: &mut AppContext,
+    account_id: &AccountId,
+) -> bool {
+    let sort = *ctx.message_sort.peek();
+    let saved = crate::ui_prefs::load_last_mailbox(account_id);
+    let ack = crate::ui_prefs::load_ack_unread(account_id);
+    match hydrate_account(cache, account_id, sort, saved.as_ref(), &ack).await {
+        Ok(Some(hydrated)) => {
+            apply_hydrated(ctx, hydrated);
+            true
+        }
+        Ok(None) => false,
+        Err(e) => {
+            warn!("mail cache hydrate failed for {account_id}: {e}");
+            false
+        }
+    }
+}
+
+async fn persist_folder_tree(cache: &dyn MailCache, ctx: &AppContext, account_id: &AccountId) {
+    let tree = {
+        let nodes = ctx.mailbox_nodes.read();
+        CachedFolderTree::from_nodes(account_id, &nodes)
+    };
+    if tree.folders.is_empty() {
+        return;
+    }
+    if let Err(e) = cache.save_folders(account_id, &tree).await {
+        warn!("mail cache save folders failed: {e}");
+    }
+}
+
+async fn persist_selected_messages(cache: &dyn MailCache, ctx: &AppContext) {
+    let Some(account_id) = ctx.selected_account.read().clone() else {
+        return;
+    };
+    let Some(mailbox_id) = ctx.selected_mailbox.read().clone() else {
+        return;
+    };
+    let sort = *ctx.message_sort.peek();
+    let (total, unread, prefix) = {
+        let list = ctx.messages.read();
+        let total = list.total_count();
+        let unread = ctx
+            .mailbox_nodes
+            .read()
+            .get(&mailbox_id)
+            .map(|n| n.unread_count);
+        let prefix = contiguous_envelope_prefix(|i| list.get(i).map(|m| m.envelope.clone()), total);
+        (total, unread, prefix)
+    };
+    if total > 0 && prefix.is_empty() {
+        // Don't clobber a previous prefix with an empty hole at index 0.
+        return;
+    }
+    let snapshot = CachedMessageList::from_prefix(&mailbox_id, sort, total, unread, prefix);
+    if let Err(e) = cache.save_messages(&account_id, &snapshot).await {
+        warn!("mail cache save messages failed: {e}");
+    }
+}
+
+async fn invalidate_mailbox_messages(
+    cache: &dyn MailCache,
+    account_id: &AccountId,
+    mailbox_id: &MailboxId,
+) {
+    if let Err(e) = cache.invalidate_messages(account_id, mailbox_id).await {
+        warn!("mail cache invalidate {} failed: {e}", mailbox_id.as_str());
+    }
+}
+
 async fn handle_select_mailbox(
     manager: &AccountConnectionManager,
     ctx: &mut AppContext,
@@ -933,12 +1057,35 @@ async fn handle_select_mailbox(
     {
         return;
     }
-    ctx.selection.write().clear();
-    ctx.message_view.set(MessageViewState::Empty);
-    ctx.download_status.set(HashMap::new());
-    ctx.messages.set(SparseList::new(0));
-    ctx.messages_loading.set(true);
-    ctx.selected_mailbox.set(Some(mailbox_id.clone()));
+
+    let already_showing = ctx.selected_mailbox.read().as_ref() == Some(&mailbox_id)
+        && ctx.messages.read().cached_count() > 0;
+    if !already_showing {
+        ctx.selection.write().clear();
+        ctx.message_view.set(MessageViewState::Empty);
+        ctx.download_status.set(HashMap::new());
+        ctx.selected_mailbox.set(Some(mailbox_id.clone()));
+        let sort = *ctx.message_sort.peek();
+        let account = ctx.selected_account.read().clone();
+        let hydrated = match account {
+            Some(account_id) => manager
+                .cache()
+                .load_messages(&account_id, &mailbox_id, sort)
+                .await
+                .ok()
+                .flatten(),
+            None => None,
+        };
+        if let Some(cached) = hydrated {
+            apply_cached_message_list(ctx, &cached);
+        } else {
+            ctx.messages.set(SparseList::new(0));
+            ctx.messages_loading.set(true);
+        }
+    } else {
+        ctx.selected_mailbox.set(Some(mailbox_id.clone()));
+        ctx.messages_loading.set(false);
+    }
 
     let Some(account_id) = ctx.selected_account.read().clone() else {
         error!("SelectMailbox: no account selected");
@@ -946,7 +1093,7 @@ async fn handle_select_mailbox(
         return;
     };
     let Some(connector) = manager.get(&account_id) else {
-        error!("SelectMailbox: no connector for {}", account_id);
+        // Offline / still connecting: keep the cache visible.
         ctx.messages_loading.set(false);
         return;
     };
@@ -965,12 +1112,43 @@ async fn handle_select_mailbox(
                 .set(state.supports_size_sender);
             ctx.message_sort.set(state.sort);
             crate::ui_prefs::save_last_mailbox(&account_id, &mailbox_id);
-            ctx.messages.set(SparseList::new(state.total));
-            ctx.messages_loading.set(false);
             acknowledge_mailbox_open(ctx, &account_id, &mailbox_id, state.total, state.unread);
+
+            // Fetch the first page, then swap the list atomically so a cache
+            // hit stays on screen until live envelopes arrive.
+            let end = state.total.min(20);
+            let live = if end > 0 {
+                connector.list_envelopes_range(&folder_id, 0..end).await
+            } else {
+                Ok(Vec::new())
+            };
+            if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id) {
+                return;
+            }
+            match live {
+                Ok(envelopes) => {
+                    let mut list = SparseList::new(state.total);
+                    let batch: Vec<_> = envelopes.into_iter().map(|e| Arc::new(e.into())).collect();
+                    list.insert_batch(0, batch);
+                    ctx.messages.set(list);
+                    ctx.messages_loading.set(false);
+                    persist_selected_messages(manager.cache(), ctx).await;
+                    persist_folder_tree(manager.cache(), ctx, &account_id).await;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to fetch first page of {}: {}",
+                        mailbox_id.as_str(),
+                        e
+                    );
+                    ctx.messages_loading.set(false);
+                    if ctx.messages.read().total_count() == 0 {
+                        ctx.messages.set(SparseList::new(state.total));
+                    }
+                }
+            }
+
             if select_first && state.total > 0 {
-                let end = state.total.min(20);
-                handle_fetch_message_range(manager, ctx, mailbox_id.clone(), 0..end).await;
                 let first_id = ctx.messages.read().get(0).map(|m| m.id.clone());
                 if let Some(id) = first_id {
                     // Unread-first: selecting the top row would immediately
@@ -997,6 +1175,9 @@ async fn handle_set_message_sort(
     let Some(mailbox_id) = ctx.selected_mailbox.read().clone() else {
         return;
     };
+    // Drop the previous sort's rows so we don't treat them as a cache hit.
+    ctx.messages.set(SparseList::new(0));
+    ctx.messages_loading.set(true);
     handle_select_mailbox(manager, ctx, mailbox_id, true).await;
 }
 
@@ -1009,9 +1190,13 @@ async fn handle_fetch_message_range(
     if ctx.selected_mailbox.read().as_ref() != Some(&mailbox_id) {
         return;
     }
-    if range.start >= range.end {
+    let total = ctx.messages.read().total_count();
+    let start = range.start.min(total);
+    let end = range.end.min(total);
+    if start >= end {
         return;
     }
+    let range = start..end;
 
     let already = {
         let messages = ctx.messages.read();
@@ -1046,6 +1231,8 @@ async fn handle_fetch_message_range(
             }
             let batch: Vec<_> = envelopes.into_iter().map(|e| Arc::new(e.into())).collect();
             ctx.messages.write().insert_batch(range.start, batch);
+            // Extending the contiguous head updates the persisted prefix.
+            persist_selected_messages(manager.cache(), ctx).await;
         }
         Err(e) => {
             error!(
@@ -1258,6 +1445,11 @@ async fn handle_select_message(
                         true,
                     )
                     .await;
+                    persist_selected_messages(manager.cache(), ctx).await;
+                    let account_id = ctx.selected_account.read().clone();
+                    if let Some(account_id) = account_id {
+                        persist_folder_tree(manager.cache(), ctx, &account_id).await;
+                    }
                 }
             }
         }
@@ -1489,6 +1681,8 @@ async fn handle_mark_read(
         return;
     }
     relocate_unread_sort_rows(connector, ctx, &message_ids, is_read).await;
+    persist_selected_messages(manager.cache(), ctx).await;
+    persist_folder_tree(manager.cache(), ctx, &account_id).await;
 }
 
 /// Slide rows in the unread-first index without SELECT/SEARCH or a list rebuild.
@@ -1564,7 +1758,7 @@ async fn handle_move_messages(
                 ctx.show_toast(ToastAction::moved(
                     dest_label,
                     MoveUndo {
-                        from: dest_mailbox_id,
+                        from: dest_mailbox_id.clone(),
                         to: mailbox_id,
                         dest_ids,
                         snapshots,
@@ -1574,6 +1768,9 @@ async fn handle_move_messages(
                 ctx.show_toast(ToastAction::info(format!("Moved to {dest_label}")));
             }
             select_after_removed_row(manager, ctx, removed_sel).await;
+            persist_selected_messages(manager.cache(), ctx).await;
+            persist_folder_tree(manager.cache(), ctx, &account_id).await;
+            invalidate_mailbox_messages(manager.cache(), &account_id, &dest_mailbox_id).await;
         }
         Err(mailiner_core::MailinerError::PartialMove {
             dest_ids: _,
@@ -1647,7 +1844,7 @@ async fn handle_move_to_trash(
             let dest_ids = dest_uids;
             if dest_ids.len() == snapshots.len() && !dest_ids.is_empty() {
                 ctx.show_toast(ToastAction::trashed(MoveUndo {
-                    from: trash_id,
+                    from: trash_id.clone(),
                     to: mailbox_id,
                     dest_ids,
                     snapshots,
@@ -1656,6 +1853,9 @@ async fn handle_move_to_trash(
                 ctx.show_toast(ToastAction::info("Moved to Trash"));
             }
             select_after_removed_row(manager, ctx, removed_sel).await;
+            persist_selected_messages(manager.cache(), ctx).await;
+            persist_folder_tree(manager.cache(), ctx, &account_id).await;
+            invalidate_mailbox_messages(manager.cache(), &account_id, &trash_id).await;
         }
         Err(mailiner_core::MailinerError::PartialMove {
             dest_ids: _,
@@ -1705,6 +1905,11 @@ async fn schedule_permanent_delete(
     let (snapshots, removed_sel) = take_messages_from_ui(ctx, message_ids);
     ctx.show_toast(ToastAction::deleted(mailbox_id, snapshots));
     select_after_removed_row(manager, ctx, removed_sel).await;
+    let account_id = ctx.selected_account.read().clone();
+    if let Some(account_id) = account_id {
+        persist_selected_messages(manager.cache(), ctx).await;
+        persist_folder_tree(manager.cache(), ctx, &account_id).await;
+    }
 }
 
 async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, undo: UndoRequest) {
@@ -1715,6 +1920,11 @@ async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, u
         } => {
             restore_snapshots(ctx, &mailbox_id, snapshots, None);
             ctx.show_toast(ToastAction::info("Undone"));
+            let account_id = ctx.selected_account.read().clone();
+            if let Some(account_id) = account_id {
+                persist_selected_messages(manager.cache(), ctx).await;
+                persist_folder_tree(manager.cache(), ctx, &account_id).await;
+            }
         }
         UndoRequest::ReverseMove(undo) => {
             let Some(account_id) = ctx.selected_account.read().clone() else {
@@ -1741,6 +1951,9 @@ async fn handle_undo(manager: &AccountConnectionManager, ctx: &mut AppContext, u
                     let new_ids = new_uids;
                     restore_snapshots(ctx, &undo.to, undo.snapshots, Some(&new_ids));
                     ctx.show_toast(ToastAction::info("Undone"));
+                    persist_selected_messages(manager.cache(), ctx).await;
+                    persist_folder_tree(manager.cache(), ctx, &account_id).await;
+                    invalidate_mailbox_messages(manager.cache(), &account_id, &undo.from).await;
                 }
                 Err(e) => {
                     error!("Failed to undo move: {}", e);

--- a/crates/mailiner-app/src/lib.rs
+++ b/crates/mailiner-app/src/lib.rs
@@ -5,6 +5,7 @@ pub mod account_store;
 pub mod download;
 pub mod formatter;
 pub mod layout;
+pub mod mail_cache;
 pub mod mailbox;
 pub mod message;
 pub mod message_loader;

--- a/crates/mailiner-app/src/mail_cache.rs
+++ b/crates/mailiner-app/src/mail_cache.rs
@@ -1,0 +1,1126 @@
+//! Local mailbox-tree and message-list cache.
+//!
+//! Persistence is abstract via [`MailCache`] so the browser can use
+//! `localStorage` while host unit tests use an in-memory backend.
+//!
+//! Message lists are stored as a **contiguous prefix** (indices `0..n`) so
+//! virtual-scroll incremental loading is unchanged: holes beyond the prefix
+//! still surface as [`crate::components::virtual_scroll::SparseList::missing_ranges`].
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use mailiner_core::ids::AccountId;
+use mailiner_core::models::{Envelope, Folder, FolderCounts, MessageSort};
+use serde::{Deserialize, Serialize};
+
+use crate::account_store::{AccountStoreError, MemoryKvStore, StringKvStore, WebLocalStorage};
+use crate::mailbox::{
+    MailboxId, MailboxNode, apply_folder_counts, apply_unread_new_state, build_mailbox_tree,
+    resolve_startup_mailbox,
+};
+use crate::message::Message;
+
+/// `localStorage` key for the v1 mail cache blob.
+pub const MAIL_CACHE_LOCAL_STORAGE_KEY: &str = "mailiner.cache.v1";
+/// Schema version for [`MailCacheBlob`].
+pub const MAIL_CACHE_SCHEMA_VERSION: u32 = 1;
+/// Max message-list snapshots retained per account (LRU by last access).
+pub const MAX_CACHED_FOLDERS: usize = 8;
+/// Max contiguous prefix envelopes stored per folder.
+pub const MAX_MESSAGES_PER_FOLDER: usize = 50;
+/// Soft cap on the encoded JSON blob (leave room for accounts + outbox).
+pub const MAX_CACHE_BLOB_BYTES: usize = 1_500_000;
+
+/// Persistence for mailbox trees and message-list prefixes.
+///
+/// `?Send` because the browser/WASM target is single-threaded.
+#[async_trait(?Send)]
+pub trait MailCache {
+    /// Last cached folder list + STATUS totals for `account_id`.
+    async fn load_folders(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Option<CachedFolderTree>, AccountStoreError>;
+
+    async fn save_folders(
+        &self,
+        account_id: &AccountId,
+        tree: &CachedFolderTree,
+    ) -> Result<(), AccountStoreError>;
+
+    /// Prefix snapshot for `mailbox_id` when it was saved under `sort`.
+    ///
+    /// Returns `None` on a cache miss **or** when the stored sort does not
+    /// match (stale order must not be shown). A hit updates LRU recency.
+    async fn load_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+    ) -> Result<Option<CachedMessageList>, AccountStoreError>;
+
+    /// Store a prefix snapshot. Truncates to [`MAX_MESSAGES_PER_FOLDER`] and
+    /// evicts the least-recently-used folder when over [`MAX_CACHED_FOLDERS`].
+    async fn save_messages(
+        &self,
+        account_id: &AccountId,
+        list: &CachedMessageList,
+    ) -> Result<(), AccountStoreError>;
+
+    /// Drop a folder's message snapshot (e.g. after mail was moved into it).
+    async fn invalidate_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+    ) -> Result<(), AccountStoreError>;
+
+    async fn delete_account(&self, account_id: &AccountId) -> Result<(), AccountStoreError>;
+
+    /// Drop cache rows for accounts that are no longer known.
+    async fn retain_accounts(&self, known: &HashSet<AccountId>) -> Result<(), AccountStoreError>;
+}
+
+/// Folder LIST + STATUS snapshot for one account.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedFolderTree {
+    pub folders: Vec<Folder>,
+    /// Folder id string → `STATUS` totals.
+    #[serde(default)]
+    pub counts: HashMap<String, FolderCounts>,
+}
+
+impl CachedFolderTree {
+    pub fn new(folders: Vec<Folder>, counts: HashMap<String, FolderCounts>) -> Self {
+        Self { folders, counts }
+    }
+
+    /// Convert UI tree nodes back into a persistable snapshot.
+    pub fn from_nodes(account_id: &AccountId, nodes: &HashMap<MailboxId, MailboxNode>) -> Self {
+        let now = Utc::now();
+        let mut folders = Vec::with_capacity(nodes.len());
+        let mut counts = HashMap::with_capacity(nodes.len());
+        for node in nodes.values() {
+            folders.push(Folder {
+                id: mailiner_core::FolderId::new(node.id.as_str()),
+                account_id: account_id.clone(),
+                name: node.name.clone(),
+                parent_id: node
+                    .parent
+                    .as_ref()
+                    .map(|p| mailiner_core::FolderId::new(p.as_str())),
+                role: node.role,
+                selectable: node.selectable,
+                created_at: now,
+                updated_at: now,
+            });
+            counts.insert(
+                node.id.as_str().to_string(),
+                FolderCounts {
+                    total_messages: node.total_count as u64,
+                    unread_messages: node.unread_count as u64,
+                },
+            );
+        }
+        Self { folders, counts }
+    }
+
+    pub fn counts_by_folder_id(&self) -> HashMap<mailiner_core::FolderId, FolderCounts> {
+        self.counts
+            .iter()
+            .map(|(id, c)| (mailiner_core::FolderId::new(id.clone()), *c))
+            .collect()
+    }
+}
+
+/// Contiguous message-list prefix for one folder (indices `0..envelopes.len()`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedMessageList {
+    pub mailbox_id: String,
+    pub sort: MessageSort,
+    pub total: usize,
+    #[serde(default)]
+    pub unread: Option<usize>,
+    /// Prefix only — never a sparse window from the middle of the list.
+    pub envelopes: Vec<Envelope>,
+    pub accessed_at: DateTime<Utc>,
+}
+
+impl CachedMessageList {
+    pub fn new(
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+        total: usize,
+        unread: Option<usize>,
+        envelopes: Vec<Envelope>,
+    ) -> Self {
+        let mut envelopes = envelopes;
+        if envelopes.len() > MAX_MESSAGES_PER_FOLDER {
+            envelopes.truncate(MAX_MESSAGES_PER_FOLDER);
+        }
+        Self {
+            mailbox_id: mailbox_id.as_str().to_string(),
+            sort,
+            total,
+            unread,
+            envelopes,
+            accessed_at: Utc::now(),
+        }
+    }
+
+    /// Build a snapshot from a live sparse list: only the contiguous head.
+    pub fn from_prefix(
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+        total: usize,
+        unread: Option<usize>,
+        prefix: Vec<Envelope>,
+    ) -> Self {
+        Self::new(mailbox_id, sort, total, unread, prefix)
+    }
+
+    pub fn mailbox_id(&self) -> MailboxId {
+        MailboxId::from(self.mailbox_id.clone())
+    }
+
+    /// UI messages for indices `0..prefix.len()`, plus the cached `total`.
+    pub fn to_ui_prefix(&self) -> HydratedMessageList {
+        HydratedMessageList {
+            total: self.total,
+            prefix: self
+                .envelopes
+                .iter()
+                .cloned()
+                .map(|e| Arc::new(Message::from(e)))
+                .collect(),
+        }
+    }
+}
+
+/// Folder tree (and optional message prefix) ready to apply to UI signals.
+#[derive(Debug, Clone)]
+pub struct HydratedAccount {
+    pub roots: Vec<MailboxId>,
+    pub nodes: HashMap<MailboxId, MailboxNode>,
+    pub selected_mailbox: Option<MailboxId>,
+    pub messages: Option<HydratedMessageList>,
+}
+
+/// Cached list prefix. Caller inserts into a [`crate::components::virtual_scroll::SparseList`] at `0`.
+#[derive(Debug, Clone)]
+pub struct HydratedMessageList {
+    pub total: usize,
+    pub prefix: Vec<Arc<Message>>,
+}
+
+/// Load a cached tree (and last-mailbox prefix) for instant first paint.
+///
+/// Returns `Ok(None)` when this account has no folder snapshot.
+pub async fn hydrate_account(
+    cache: &dyn MailCache,
+    account_id: &AccountId,
+    sort: MessageSort,
+    saved_mailbox: Option<&MailboxId>,
+    acknowledged: &HashMap<MailboxId, usize>,
+) -> Result<Option<HydratedAccount>, AccountStoreError> {
+    let Some(tree) = cache.load_folders(account_id).await? else {
+        return Ok(None);
+    };
+    let (roots, mut nodes) = build_mailbox_tree(tree.folders.clone());
+    let counts = tree.counts_by_folder_id();
+    apply_folder_counts(&mut nodes, &counts);
+    apply_unread_new_state(&mut nodes, &counts, acknowledged);
+    let selected = resolve_startup_mailbox(saved_mailbox, &nodes, &roots);
+    let messages = match selected.as_ref() {
+        Some(mailbox_id) => cache
+            .load_messages(account_id, mailbox_id, sort)
+            .await?
+            .map(|list| list.to_ui_prefix()),
+        None => None,
+    };
+    Ok(Some(HydratedAccount {
+        roots,
+        nodes,
+        selected_mailbox: selected,
+        messages,
+    }))
+}
+
+/// Contiguous envelope prefix from a sparse list (stops at the first hole).
+pub fn contiguous_envelope_prefix(
+    get: impl Fn(usize) -> Option<Envelope>,
+    total: usize,
+) -> Vec<Envelope> {
+    let cap = total.min(MAX_MESSAGES_PER_FOLDER);
+    let mut out = Vec::with_capacity(cap);
+    for i in 0..cap {
+        match get(i) {
+            Some(env) => out.push(env),
+            None => break,
+        }
+    }
+    out
+}
+
+// ── Blob + LRU ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+struct AccountCacheBlob {
+    #[serde(default)]
+    folders: Option<CachedFolderTree>,
+    /// Mailbox id → prefix snapshot.
+    #[serde(default)]
+    messages: HashMap<String, CachedMessageList>,
+}
+
+/// Single JSON document stored under [`MAIL_CACHE_LOCAL_STORAGE_KEY`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MailCacheBlob {
+    pub schema_version: u32,
+    #[serde(default)]
+    accounts: HashMap<AccountId, AccountCacheBlob>,
+}
+
+impl Default for MailCacheBlob {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl MailCacheBlob {
+    pub fn empty() -> Self {
+        Self {
+            schema_version: MAIL_CACHE_SCHEMA_VERSION,
+            accounts: HashMap::new(),
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, AccountStoreError> {
+        serde_json::to_string(self).map_err(|e| AccountStoreError::Serialization(e.to_string()))
+    }
+
+    /// Deserialize. Rejects a **future** `schema_version` so a newer format is
+    /// not silently rewritten as v1.
+    pub fn decode(json: &str) -> Result<Self, AccountStoreError> {
+        let blob: Self = serde_json::from_str(json)
+            .map_err(|e| AccountStoreError::Serialization(e.to_string()))?;
+        if blob.schema_version > MAIL_CACHE_SCHEMA_VERSION {
+            return Err(AccountStoreError::Serialization(format!(
+                "unsupported mail cache schema_version {} (max supported {})",
+                blob.schema_version, MAIL_CACHE_SCHEMA_VERSION
+            )));
+        }
+        Ok(blob)
+    }
+
+    fn account_mut(&mut self, account_id: &AccountId) -> &mut AccountCacheBlob {
+        self.accounts.entry(account_id.clone()).or_default()
+    }
+
+    pub fn get_folders(&self, account_id: &AccountId) -> Option<&CachedFolderTree> {
+        self.accounts.get(account_id)?.folders.as_ref()
+    }
+
+    pub fn set_folders(&mut self, account_id: &AccountId, tree: CachedFolderTree) {
+        self.account_mut(account_id).folders = Some(tree);
+        self.schema_version = MAIL_CACHE_SCHEMA_VERSION;
+    }
+
+    /// Hit only when `sort` matches. Updates `accessed_at`.
+    pub fn take_messages(
+        &mut self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+    ) -> Option<CachedMessageList> {
+        let acc = self.accounts.get_mut(account_id)?;
+        let list = acc.messages.get_mut(mailbox_id.as_str())?;
+        if list.sort != sort {
+            return None;
+        }
+        list.accessed_at = Utc::now();
+        Some(list.clone())
+    }
+
+    pub fn set_messages(&mut self, account_id: &AccountId, mut list: CachedMessageList) {
+        if list.envelopes.len() > MAX_MESSAGES_PER_FOLDER {
+            list.envelopes.truncate(MAX_MESSAGES_PER_FOLDER);
+        }
+        list.accessed_at = Utc::now();
+        let key = list.mailbox_id.clone();
+        let acc = self.account_mut(account_id);
+        acc.messages.insert(key, list);
+        evict_lru_folders(acc);
+        self.schema_version = MAIL_CACHE_SCHEMA_VERSION;
+    }
+
+    pub fn invalidate_messages(&mut self, account_id: &AccountId, mailbox_id: &MailboxId) {
+        if let Some(acc) = self.accounts.get_mut(account_id) {
+            acc.messages.remove(mailbox_id.as_str());
+        }
+        self.schema_version = MAIL_CACHE_SCHEMA_VERSION;
+    }
+
+    pub fn delete_account(&mut self, account_id: &AccountId) {
+        self.accounts.remove(account_id);
+        self.schema_version = MAIL_CACHE_SCHEMA_VERSION;
+    }
+
+    pub fn retain_accounts(&mut self, known: &HashSet<AccountId>) {
+        self.accounts.retain(|id, _| known.contains(id));
+        self.schema_version = MAIL_CACHE_SCHEMA_VERSION;
+    }
+
+    /// Drop the globally oldest message-list snapshot. `true` if something was removed.
+    pub fn evict_oldest_message_list(&mut self) -> bool {
+        let mut oldest: Option<(AccountId, String, DateTime<Utc>)> = None;
+        for (acc_id, acc) in &self.accounts {
+            for (mb, list) in &acc.messages {
+                let worse = oldest
+                    .as_ref()
+                    .is_none_or(|(_, _, t)| list.accessed_at < *t);
+                if worse {
+                    oldest = Some((acc_id.clone(), mb.clone(), list.accessed_at));
+                }
+            }
+        }
+        let Some((acc_id, mb, _)) = oldest else {
+            return false;
+        };
+        if let Some(acc) = self.accounts.get_mut(&acc_id) {
+            acc.messages.remove(&mb);
+        }
+        true
+    }
+
+    /// Encode, evicting LRU message lists until the JSON fits `limit`.
+    pub fn encode_within(&mut self, limit: usize) -> Result<String, AccountStoreError> {
+        loop {
+            let json = self.encode()?;
+            if json.len() <= limit {
+                return Ok(json);
+            }
+            if !self.evict_oldest_message_list() {
+                return Err(AccountStoreError::Other(
+                    "mail cache exceeds storage budget and has nothing left to evict".into(),
+                ));
+            }
+        }
+    }
+}
+
+fn evict_lru_folders(acc: &mut AccountCacheBlob) {
+    while acc.messages.len() > MAX_CACHED_FOLDERS {
+        let oldest = acc
+            .messages
+            .iter()
+            .min_by(|a, b| {
+                a.1.accessed_at
+                    .cmp(&b.1.accessed_at)
+                    .then_with(|| a.0.cmp(b.0))
+            })
+            .map(|(k, _)| k.clone());
+        match oldest {
+            Some(k) => {
+                acc.messages.remove(&k);
+            }
+            None => break,
+        }
+    }
+}
+
+// ── In-memory backend ───────────────────────────────────────────────────────
+
+/// Process-memory [`MailCache`] for unit tests and session-only fallback.
+#[derive(Debug, Default)]
+pub struct InMemoryMailCache {
+    blob: RefCell<MailCacheBlob>,
+}
+
+impl InMemoryMailCache {
+    pub fn new() -> Self {
+        Self {
+            blob: RefCell::new(MailCacheBlob::empty()),
+        }
+    }
+
+    #[cfg(test)]
+    fn blob(&self) -> MailCacheBlob {
+        self.blob.borrow().clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl MailCache for InMemoryMailCache {
+    async fn load_folders(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Option<CachedFolderTree>, AccountStoreError> {
+        Ok(self.blob.borrow().get_folders(account_id).cloned())
+    }
+
+    async fn save_folders(
+        &self,
+        account_id: &AccountId,
+        tree: &CachedFolderTree,
+    ) -> Result<(), AccountStoreError> {
+        self.blob.borrow_mut().set_folders(account_id, tree.clone());
+        Ok(())
+    }
+
+    async fn load_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+    ) -> Result<Option<CachedMessageList>, AccountStoreError> {
+        Ok(self
+            .blob
+            .borrow_mut()
+            .take_messages(account_id, mailbox_id, sort))
+    }
+
+    async fn save_messages(
+        &self,
+        account_id: &AccountId,
+        list: &CachedMessageList,
+    ) -> Result<(), AccountStoreError> {
+        self.blob
+            .borrow_mut()
+            .set_messages(account_id, list.clone());
+        Ok(())
+    }
+
+    async fn invalidate_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+    ) -> Result<(), AccountStoreError> {
+        self.blob
+            .borrow_mut()
+            .invalidate_messages(account_id, mailbox_id);
+        Ok(())
+    }
+
+    async fn delete_account(&self, account_id: &AccountId) -> Result<(), AccountStoreError> {
+        self.blob.borrow_mut().delete_account(account_id);
+        Ok(())
+    }
+
+    async fn retain_accounts(&self, known: &HashSet<AccountId>) -> Result<(), AccountStoreError> {
+        self.blob.borrow_mut().retain_accounts(known);
+        Ok(())
+    }
+}
+
+// ── Browser / StringKvStore backend ─────────────────────────────────────────
+
+/// [`MailCache`] over a string key-value store (`localStorage` in production).
+pub struct BrowserMailCache<K: StringKvStore = WebLocalStorage> {
+    kv: K,
+}
+
+impl BrowserMailCache<WebLocalStorage> {
+    /// Open `window.localStorage`, or [`AccountStoreError::Unavailable`].
+    pub async fn open() -> Result<Self, AccountStoreError> {
+        Ok(Self {
+            kv: WebLocalStorage::try_open()?,
+        })
+    }
+}
+
+impl BrowserMailCache<MemoryKvStore> {
+    pub fn open_memory() -> Self {
+        Self {
+            kv: MemoryKvStore::new(),
+        }
+    }
+}
+
+impl<K: StringKvStore> BrowserMailCache<K> {
+    pub fn with_kv(kv: K) -> Self {
+        Self { kv }
+    }
+
+    fn load_blob(&self) -> Result<MailCacheBlob, AccountStoreError> {
+        match self.kv.get_item(MAIL_CACHE_LOCAL_STORAGE_KEY)? {
+            None => Ok(MailCacheBlob::empty()),
+            Some(s) if s.trim().is_empty() => Ok(MailCacheBlob::empty()),
+            Some(s) => MailCacheBlob::decode(&s),
+        }
+    }
+
+    fn save_blob(&self, blob: &mut MailCacheBlob) -> Result<(), AccountStoreError> {
+        let mut json = blob.encode_within(MAX_CACHE_BLOB_BYTES)?;
+        loop {
+            match self.kv.set_item(MAIL_CACHE_LOCAL_STORAGE_KEY, &json) {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    if !blob.evict_oldest_message_list() {
+                        return Err(err);
+                    }
+                    json = blob.encode_within(MAX_CACHE_BLOB_BYTES)?;
+                }
+            }
+        }
+    }
+
+    fn mutate<T>(
+        &self,
+        f: impl FnOnce(&mut MailCacheBlob) -> Result<T, AccountStoreError>,
+    ) -> Result<T, AccountStoreError> {
+        let mut blob = self.load_blob()?;
+        let out = f(&mut blob)?;
+        self.save_blob(&mut blob)?;
+        Ok(out)
+    }
+}
+
+impl<K: StringKvStore> fmt::Debug for BrowserMailCache<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BrowserMailCache").finish_non_exhaustive()
+    }
+}
+
+#[async_trait(?Send)]
+impl<K: StringKvStore> MailCache for BrowserMailCache<K> {
+    async fn load_folders(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Option<CachedFolderTree>, AccountStoreError> {
+        Ok(self.load_blob()?.get_folders(account_id).cloned())
+    }
+
+    async fn save_folders(
+        &self,
+        account_id: &AccountId,
+        tree: &CachedFolderTree,
+    ) -> Result<(), AccountStoreError> {
+        self.mutate(|blob| {
+            blob.set_folders(account_id, tree.clone());
+            Ok(())
+        })
+    }
+
+    async fn load_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+        sort: MessageSort,
+    ) -> Result<Option<CachedMessageList>, AccountStoreError> {
+        let mut blob = self.load_blob()?;
+        let got = blob.take_messages(account_id, mailbox_id, sort);
+        // Only persist the LRU touch on a hit.
+        if got.is_some() {
+            self.save_blob(&mut blob)?;
+        }
+        Ok(got)
+    }
+
+    async fn save_messages(
+        &self,
+        account_id: &AccountId,
+        list: &CachedMessageList,
+    ) -> Result<(), AccountStoreError> {
+        self.mutate(|blob| {
+            blob.set_messages(account_id, list.clone());
+            Ok(())
+        })
+    }
+
+    async fn invalidate_messages(
+        &self,
+        account_id: &AccountId,
+        mailbox_id: &MailboxId,
+    ) -> Result<(), AccountStoreError> {
+        self.mutate(|blob| {
+            blob.invalidate_messages(account_id, mailbox_id);
+            Ok(())
+        })
+    }
+
+    async fn delete_account(&self, account_id: &AccountId) -> Result<(), AccountStoreError> {
+        self.mutate(|blob| {
+            blob.delete_account(account_id);
+            Ok(())
+        })
+    }
+
+    async fn retain_accounts(&self, known: &HashSet<AccountId>) -> Result<(), AccountStoreError> {
+        self.mutate(|blob| {
+            blob.retain_accounts(known);
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use mailiner_core::{AccountId, EmailAddr, EmailAddress, FolderId, MailboxRole, MessageId};
+
+    fn ts() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap()
+    }
+
+    fn folder(account: &str, id: &str, name: &str, role: MailboxRole) -> Folder {
+        Folder {
+            id: FolderId::new(id),
+            account_id: AccountId::new(account),
+            name: name.into(),
+            parent_id: None,
+            role,
+            selectable: true,
+            created_at: ts(),
+            updated_at: ts(),
+        }
+    }
+
+    fn envelope(folder: &str, uid: &str, subject: &str) -> Envelope {
+        let folder_id = FolderId::new(folder);
+        Envelope {
+            id: MessageId::new(folder_id.clone(), uid),
+            account_id: AccountId::new("acc"),
+            folder_id,
+            subject: Some(subject.into()),
+            from: Some(EmailAddress::List(vec![EmailAddr {
+                name: Some("Ada".into()),
+                email: Some("ada@example.com".into()),
+            }])),
+            to: None,
+            cc: None,
+            bcc: None,
+            reply_to: None,
+            rfc_message_id: None,
+            in_reply_to: None,
+            references: vec![],
+            date: ts(),
+            is_read: false,
+            is_starred: false,
+            is_flagged: false,
+            is_draft: false,
+            is_deleted: false,
+            has_attachments: false,
+            size: None,
+            created_at: ts(),
+            updated_at: ts(),
+        }
+    }
+
+    fn list_for(mailbox: &str, n: usize, total: usize, sort: MessageSort) -> CachedMessageList {
+        let envs: Vec<_> = (1..=n)
+            .map(|i| envelope(mailbox, &i.to_string(), &format!("s{i}")))
+            .collect();
+        let mut list = CachedMessageList::new(
+            &MailboxId::from(mailbox.to_string()),
+            sort,
+            total,
+            Some(n),
+            envs,
+        );
+        // Stable recency for LRU tests (constructor stamps Utc::now()).
+        list.accessed_at = ts();
+        list
+    }
+
+    // ── Blob helpers ────────────────────────────────────────────────────────
+
+    #[test]
+    fn storage_key_is_versioned() {
+        assert_eq!(MAIL_CACHE_LOCAL_STORAGE_KEY, "mailiner.cache.v1");
+        assert_eq!(MAIL_CACHE_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn blob_encode_decode_roundtrip() {
+        let acc = AccountId::new("a1");
+        let mut blob = MailCacheBlob::empty();
+        blob.set_folders(
+            &acc,
+            CachedFolderTree::new(
+                vec![folder("a1", "INBOX", "INBOX", MailboxRole::Inbox)],
+                HashMap::from([(
+                    "INBOX".into(),
+                    FolderCounts {
+                        total_messages: 3,
+                        unread_messages: 1,
+                    },
+                )]),
+            ),
+        );
+        let json = blob.encode().unwrap();
+        assert!(json.contains("\"schema_version\":1"), "json={json}");
+        assert!(json.contains("INBOX"), "json={json}");
+        let back = MailCacheBlob::decode(&json).unwrap();
+        assert_eq!(back, blob);
+    }
+
+    #[test]
+    fn blob_decode_rejects_future_schema() {
+        let json = r#"{"schema_version":99,"accounts":{}}"#;
+        let err = MailCacheBlob::decode(json).unwrap_err();
+        match err {
+            AccountStoreError::Serialization(msg) => {
+                assert!(
+                    msg.contains("unsupported") && msg.contains("99"),
+                    "msg={msg}"
+                );
+            }
+            other => panic!("expected Serialization, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_messages_truncates_prefix() {
+        let mut blob = MailCacheBlob::empty();
+        let acc = AccountId::new("a");
+        let oversized: Vec<_> = (1..=MAX_MESSAGES_PER_FOLDER + 10)
+            .map(|i| envelope("INBOX", &i.to_string(), "x"))
+            .collect();
+        blob.set_messages(
+            &acc,
+            CachedMessageList::new(
+                &MailboxId::from("INBOX".to_string()),
+                MessageSort::Arrival,
+                200,
+                None,
+                oversized,
+            ),
+        );
+        let got = blob
+            .take_messages(
+                &acc,
+                &MailboxId::from("INBOX".to_string()),
+                MessageSort::Arrival,
+            )
+            .unwrap();
+        assert_eq!(got.envelopes.len(), MAX_MESSAGES_PER_FOLDER);
+        assert_eq!(got.total, 200);
+    }
+
+    #[test]
+    fn lru_evicts_oldest_folder_over_limit() {
+        let mut blob = MailCacheBlob::empty();
+        let acc = AccountId::new("a");
+        for i in 0..=MAX_CACHED_FOLDERS {
+            let name = format!("F{i}");
+            let mut list = list_for(&name, 1, 1, MessageSort::Arrival);
+            list.accessed_at = ts() + chrono::Duration::seconds(i as i64);
+            blob.set_messages(&acc, list);
+        }
+        let acc_blob = blob.accounts.get(&acc).unwrap();
+        assert_eq!(acc_blob.messages.len(), MAX_CACHED_FOLDERS);
+        assert!(
+            !acc_blob.messages.contains_key("F0"),
+            "oldest folder should be evicted: {:?}",
+            acc_blob.messages.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            acc_blob
+                .messages
+                .contains_key(&format!("F{MAX_CACHED_FOLDERS}"))
+        );
+    }
+
+    #[test]
+    fn take_messages_misses_on_sort_mismatch() {
+        let mut blob = MailCacheBlob::empty();
+        let acc = AccountId::new("a");
+        blob.set_messages(&acc, list_for("INBOX", 2, 2, MessageSort::Arrival));
+        assert!(
+            blob.take_messages(
+                &acc,
+                &MailboxId::from("INBOX".to_string()),
+                MessageSort::Unread
+            )
+            .is_none()
+        );
+        assert!(
+            blob.take_messages(
+                &acc,
+                &MailboxId::from("INBOX".to_string()),
+                MessageSort::Arrival
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn encode_within_evicts_until_fit() {
+        let mut blob = MailCacheBlob::empty();
+        let acc = AccountId::new("a");
+        for i in 0..4 {
+            let mut list = list_for(&format!("F{i}"), 8, 8, MessageSort::Arrival);
+            list.accessed_at = ts() + chrono::Duration::seconds(i as i64);
+            blob.set_messages(&acc, list);
+        }
+        let full = blob.encode().unwrap().len();
+        assert!(full > 200, "fixture too small to exercise budget: {full}");
+        let json = blob.encode_within(full / 2).unwrap();
+        assert!(json.len() <= full / 2);
+        let back = MailCacheBlob::decode(&json).unwrap();
+        let left = back.accounts.get(&acc).unwrap().messages.len();
+        assert!(left < 4, "expected eviction, still {left} lists");
+        assert!(
+            !back.accounts.get(&acc).unwrap().messages.contains_key("F0"),
+            "oldest list should go first"
+        );
+    }
+
+    #[test]
+    fn retain_accounts_drops_unknown() {
+        let mut blob = MailCacheBlob::empty();
+        blob.set_folders(
+            &AccountId::new("keep"),
+            CachedFolderTree::new(vec![], HashMap::new()),
+        );
+        blob.set_folders(
+            &AccountId::new("gone"),
+            CachedFolderTree::new(vec![], HashMap::new()),
+        );
+        blob.retain_accounts(&HashSet::from([AccountId::new("keep")]));
+        assert!(blob.get_folders(&AccountId::new("keep")).is_some());
+        assert!(blob.get_folders(&AccountId::new("gone")).is_none());
+    }
+
+    // ── Trait backends ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn in_memory_folders_and_messages_roundtrip() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("acc");
+        let inbox = MailboxId::from("INBOX".to_string());
+        let tree = CachedFolderTree::new(
+            vec![folder("acc", "INBOX", "INBOX", MailboxRole::Inbox)],
+            HashMap::from([(
+                "INBOX".into(),
+                FolderCounts {
+                    total_messages: 2,
+                    unread_messages: 1,
+                },
+            )]),
+        );
+        cache.save_folders(&acc, &tree).await.unwrap();
+        cache
+            .save_messages(&acc, &list_for("INBOX", 2, 10, MessageSort::Arrival))
+            .await
+            .unwrap();
+
+        let loaded = cache.load_folders(&acc).await.unwrap().unwrap();
+        assert_eq!(loaded.folders.len(), 1);
+        assert_eq!(loaded.counts["INBOX"].total_messages, 2);
+
+        let msgs = cache
+            .load_messages(&acc, &inbox, MessageSort::Arrival)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msgs.mailbox_id().as_str(), "INBOX");
+        assert_eq!(msgs.envelopes.len(), 2);
+        assert_eq!(msgs.total, 10);
+        assert_eq!(msgs.envelopes[0].subject.as_deref(), Some("s1"));
+    }
+
+    #[tokio::test]
+    async fn browser_memory_kv_same_as_in_memory() {
+        let cache = BrowserMailCache::<MemoryKvStore>::open_memory();
+        let acc = AccountId::new("acc");
+        cache
+            .save_folders(
+                &acc,
+                &CachedFolderTree::new(
+                    vec![folder("acc", "Sent", "Sent", MailboxRole::Sent)],
+                    HashMap::new(),
+                ),
+            )
+            .await
+            .unwrap();
+        let got = cache.load_folders(&acc).await.unwrap().unwrap();
+        assert_eq!(got.folders[0].name, "Sent");
+        let raw = cache
+            .kv
+            .get_item(MAIL_CACHE_LOCAL_STORAGE_KEY)
+            .unwrap()
+            .expect("blob written");
+        assert!(raw.contains("Sent"), "json={raw}");
+        assert!(
+            raw.contains("\"schema_version\":1"),
+            "schema missing: {raw}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_and_delete_account() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("acc");
+        let inbox = MailboxId::from("INBOX".to_string());
+        cache
+            .save_messages(&acc, &list_for("INBOX", 1, 1, MessageSort::Arrival))
+            .await
+            .unwrap();
+        cache.invalidate_messages(&acc, &inbox).await.unwrap();
+        assert!(
+            cache
+                .load_messages(&acc, &inbox, MessageSort::Arrival)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        cache
+            .save_folders(
+                &acc,
+                &CachedFolderTree::new(
+                    vec![folder("acc", "INBOX", "INBOX", MailboxRole::Inbox)],
+                    HashMap::new(),
+                ),
+            )
+            .await
+            .unwrap();
+        cache.delete_account(&acc).await.unwrap();
+        assert!(cache.load_folders(&acc).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn hydrate_builds_tree_and_prefix() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("acc");
+        let inbox = MailboxId::from("INBOX".to_string());
+        cache
+            .save_folders(
+                &acc,
+                &CachedFolderTree::new(
+                    vec![
+                        folder("acc", "INBOX", "INBOX", MailboxRole::Inbox),
+                        folder("acc", "Sent", "Sent", MailboxRole::Sent),
+                    ],
+                    HashMap::from([(
+                        "INBOX".into(),
+                        FolderCounts {
+                            total_messages: 100,
+                            unread_messages: 4,
+                        },
+                    )]),
+                ),
+            )
+            .await
+            .unwrap();
+        cache
+            .save_messages(&acc, &list_for("INBOX", 5, 100, MessageSort::Arrival))
+            .await
+            .unwrap();
+
+        let mut ack = HashMap::new();
+        ack.insert(inbox.clone(), 4);
+        let hydrated = hydrate_account(&cache, &acc, MessageSort::Arrival, Some(&inbox), &ack)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(hydrated.roots.len(), 2);
+        assert_eq!(
+            hydrated.selected_mailbox.as_ref().unwrap().as_str(),
+            "INBOX"
+        );
+        let node = hydrated.nodes.get(&inbox).unwrap();
+        assert_eq!(node.unread_count, 4);
+        assert_eq!(node.total_count, 100);
+        assert!(!node.has_new);
+        let msgs = hydrated.messages.unwrap();
+        assert_eq!(msgs.total, 100);
+        assert_eq!(msgs.prefix.len(), 5);
+        assert_eq!(msgs.prefix[0].subject, "s1");
+    }
+
+    #[tokio::test]
+    async fn hydrate_skips_messages_when_sort_differs() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("acc");
+        cache
+            .save_folders(
+                &acc,
+                &CachedFolderTree::new(
+                    vec![folder("acc", "INBOX", "INBOX", MailboxRole::Inbox)],
+                    HashMap::new(),
+                ),
+            )
+            .await
+            .unwrap();
+        cache
+            .save_messages(&acc, &list_for("INBOX", 3, 3, MessageSort::Arrival))
+            .await
+            .unwrap();
+        let hydrated = hydrate_account(&cache, &acc, MessageSort::Unread, None, &HashMap::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(hydrated.messages.is_none());
+        assert_eq!(
+            hydrated.selected_mailbox.as_ref().map(|id| id.as_str()),
+            Some("INBOX")
+        );
+    }
+
+    #[test]
+    fn cached_prefix_is_contiguous_head_for_virtual_scroll() {
+        let list = list_for("INBOX", 5, 40, MessageSort::Arrival);
+        let ui = list.to_ui_prefix();
+        // SparseList is filled only at 0..prefix.len(); the rest stay holes
+        // so virtual scroll still requests FetchMessageRange for 5..40.
+        assert_eq!(ui.total, 40);
+        assert_eq!(ui.prefix.len(), 5);
+        assert_eq!(ui.prefix[0].id.as_uid(), "1");
+        assert_eq!(ui.prefix[4].id.as_uid(), "5");
+    }
+
+    #[test]
+    fn contiguous_prefix_stops_at_first_hole() {
+        let items = [
+            Some(envelope("INBOX", "1", "a")),
+            Some(envelope("INBOX", "2", "b")),
+            None,
+            Some(envelope("INBOX", "4", "d")),
+        ];
+        let prefix = contiguous_envelope_prefix(|i| items.get(i).and_then(|e| e.clone()), 10);
+        assert_eq!(prefix.len(), 2);
+        assert_eq!(prefix[1].subject.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn hydrate_none_without_folder_cache() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("missing");
+        let out = futures_executor::block_on(hydrate_account(
+            &cache,
+            &acc,
+            MessageSort::Arrival,
+            None,
+            &HashMap::new(),
+        ))
+        .unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn in_memory_lru_matches_blob() {
+        let cache = InMemoryMailCache::new();
+        let acc = AccountId::new("a");
+        futures_executor::block_on(async {
+            for i in 0..=MAX_CACHED_FOLDERS {
+                let mut list = list_for(&format!("F{i}"), 1, 1, MessageSort::Arrival);
+                list.accessed_at = ts() + chrono::Duration::seconds(i as i64);
+                cache.save_messages(&acc, &list).await.unwrap();
+            }
+        });
+        let blob = cache.blob();
+        assert_eq!(
+            blob.accounts.get(&acc).unwrap().messages.len(),
+            MAX_CACHED_FOLDERS
+        );
+        assert!(!blob.accounts.get(&acc).unwrap().messages.contains_key("F0"));
+    }
+}

--- a/crates/mailiner-app/src/mail_cache.rs
+++ b/crates/mailiner-app/src/mail_cache.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use dioxus::logger::tracing::warn;
 use mailiner_core::ids::AccountId;
 use mailiner_core::models::{Envelope, Folder, FolderCounts, MessageSort};
 use serde::{Deserialize, Serialize};
@@ -126,6 +127,11 @@ impl CachedFolderTree {
                 },
             );
         }
+        folders.sort_by(|a, b| {
+            folder_depth(&MailboxId::from(a.id.clone()), nodes)
+                .cmp(&folder_depth(&MailboxId::from(b.id.clone()), nodes))
+                .then_with(|| a.id.to_string().cmp(&b.id.to_string()))
+        });
         Self { folders, counts }
     }
 
@@ -135,6 +141,19 @@ impl CachedFolderTree {
             .map(|(id, c)| (mailiner_core::FolderId::new(id.clone()), *c))
             .collect()
     }
+}
+
+fn folder_depth(id: &MailboxId, nodes: &HashMap<MailboxId, MailboxNode>) -> usize {
+    let mut depth = 0;
+    let mut current = nodes.get(id).and_then(|n| n.parent.clone());
+    while let Some(parent) = current {
+        depth += 1;
+        current = nodes.get(&parent).and_then(|n| n.parent.clone());
+        if depth > 64 {
+            break;
+        }
+    }
+    depth
 }
 
 /// Contiguous message-list prefix for one folder (indices `0..envelopes.len()`).
@@ -236,10 +255,15 @@ pub async fn hydrate_account(
     apply_unread_new_state(&mut nodes, &counts, acknowledged);
     let selected = resolve_startup_mailbox(saved_mailbox, &nodes, &roots);
     let messages = match selected.as_ref() {
-        Some(mailbox_id) => cache
-            .load_messages(account_id, mailbox_id, sort)
-            .await?
-            .map(|list| list.to_ui_prefix()),
+        Some(mailbox_id) => match cache.load_messages(account_id, mailbox_id, sort).await {
+            Ok(list) => list.map(|list| list.to_ui_prefix()),
+            Err(e) => {
+                // Keep the folder tree; a list read / LRU-touch write must
+                // not look like a cache miss to the caller.
+                warn!("mail cache load messages failed for {account_id}: {e}");
+                None
+            }
+        },
         None => None,
     };
     Ok(Some(HydratedAccount {
@@ -614,9 +638,12 @@ impl<K: StringKvStore> MailCache for BrowserMailCache<K> {
     ) -> Result<Option<CachedMessageList>, AccountStoreError> {
         let mut blob = self.load_blob()?;
         let got = blob.take_messages(account_id, mailbox_id, sort);
-        // Only persist the LRU touch on a hit.
-        if got.is_some() {
-            self.save_blob(&mut blob)?;
+        // Only persist the LRU touch on a hit. A failed recency write must
+        // still return the already-loaded prefix.
+        if got.is_some()
+            && let Err(e) = self.save_blob(&mut blob)
+        {
+            warn!("mail cache LRU touch failed: {e}");
         }
         Ok(got)
     }
@@ -669,11 +696,21 @@ mod tests {
     }
 
     fn folder(account: &str, id: &str, name: &str, role: MailboxRole) -> Folder {
+        folder_parent(account, id, name, None, role)
+    }
+
+    fn folder_parent(
+        account: &str,
+        id: &str,
+        name: &str,
+        parent: Option<&str>,
+        role: MailboxRole,
+    ) -> Folder {
         Folder {
             id: FolderId::new(id),
             account_id: AccountId::new(account),
             name: name.into(),
-            parent_id: None,
+            parent_id: parent.map(FolderId::new),
             role,
             selectable: true,
             created_at: ts(),
@@ -1062,6 +1099,48 @@ mod tests {
         assert_eq!(
             hydrated.selected_mailbox.as_ref().map(|id| id.as_str()),
             Some("INBOX")
+        );
+    }
+
+    #[test]
+    fn from_nodes_roundtrip_keeps_nested_children() {
+        let acc = AccountId::new("acc");
+        let (roots, nodes) = build_mailbox_tree(vec![
+            folder_parent("acc", "KDE.pim", "pim", Some("KDE"), MailboxRole::Other),
+            folder_parent("acc", "KDE", "KDE", None, MailboxRole::Other),
+        ]);
+        assert!(
+            nodes
+                .get(&MailboxId::from("KDE".to_string()))
+                .is_some_and(|n| n.children.iter().any(|c| c.as_str() == "KDE.pim")),
+            "precondition: child-first LIST must keep the child"
+        );
+        let tree = CachedFolderTree::from_nodes(&acc, &nodes);
+        assert!(
+            tree.folders
+                .iter()
+                .position(|f| f.id.to_string() == "KDE")
+                .zip(
+                    tree.folders
+                        .iter()
+                        .position(|f| f.id.to_string() == "KDE.pim")
+                )
+                .is_some_and(|(parent, child)| parent < child),
+            "parent should be persisted before child: {:?}",
+            tree.folders
+                .iter()
+                .map(|f| f.id.to_string())
+                .collect::<Vec<_>>()
+        );
+        let (roots2, nodes2) = build_mailbox_tree(tree.folders);
+        assert_eq!(roots.len(), roots2.len());
+        let kde = nodes2
+            .get(&MailboxId::from("KDE".to_string()))
+            .expect("parent after hydrate");
+        assert!(
+            kde.children.iter().any(|id| id.as_str() == "KDE.pim"),
+            "cached nested child disappeared: {:?}",
+            kde.children
         );
     }
 

--- a/crates/mailiner-app/src/mailbox.rs
+++ b/crates/mailiner-app/src/mailbox.rs
@@ -96,7 +96,6 @@ pub fn build_mailbox_tree(
                 role,
                 selectable: folder.selectable,
             });
-        mboxes.insert(mailbox_id.clone(), folder.clone().into());
         if let Some(parent_id) = folder.parent_id.clone() {
             mboxes
                 .entry(parent_id.clone().into())
@@ -543,6 +542,23 @@ mod tests {
             false,
         )]);
         assert!(find_mailbox_with_role(&nodes, MailboxRole::Trash).is_none());
+    }
+
+    #[test]
+    fn build_tree_keeps_children_when_child_arrives_first() {
+        let (roots, nodes) = build_mailbox_tree(vec![
+            folder("KDE.pim", "pim", Some("KDE"), MailboxRole::Other),
+            folder("KDE", "KDE", None, MailboxRole::Other),
+        ]);
+        assert!(roots.iter().any(|id| id.as_str() == "KDE"));
+        let kde = nodes
+            .get(&MailboxId::from("KDE".to_string()))
+            .expect("parent");
+        assert!(
+            kde.children.iter().any(|id| id.as_str() == "KDE.pim"),
+            "synthesized parent children must survive the real folder: {:?}",
+            kde.children
+        );
     }
 
     #[test]

--- a/crates/mailiner-app/src/main.rs
+++ b/crates/mailiner-app/src/main.rs
@@ -16,6 +16,7 @@ use crate::components::{
 };
 use crate::context::AppContext;
 use crate::core_event::{InitialBootstrap, core_loop};
+use crate::mail_cache::{BrowserMailCache, InMemoryMailCache, MailCache, hydrate_account};
 use crate::outbox_store::{BrowserOutboxStore, InMemoryOutboxStore, OutboxStore};
 
 mod account;
@@ -28,6 +29,7 @@ mod core_event;
 mod download;
 mod formatter;
 mod layout;
+mod mail_cache;
 mod mailbox;
 mod message;
 mod message_loader;
@@ -122,6 +124,7 @@ fn main() {
 struct BootstrapOutcome {
     store: Rc<dyn AccountStore>,
     outbox: Rc<dyn OutboxStore>,
+    cache: Rc<dyn MailCache>,
     initial_bootstrap: InitialBootstrap,
 }
 
@@ -144,6 +147,14 @@ async fn run_bootstrap(
         }
     };
 
+    let cache: Rc<dyn MailCache> = match BrowserMailCache::open().await {
+        Ok(s) => Rc::new(s),
+        Err(e) => {
+            warn!("BrowserMailCache open failed ({e}); using in-memory mail cache");
+            Rc::new(InMemoryMailCache::new())
+        }
+    };
+
     let store: Rc<dyn AccountStore> = match BrowserAccountStore::open().await {
         Ok(s) => Rc::new(s),
         Err(e) => {
@@ -160,6 +171,7 @@ async fn run_bootstrap(
             return BootstrapOutcome {
                 store: Rc::new(InMemoryAccountStore::new()),
                 outbox,
+                cache,
                 initial_bootstrap: InitialBootstrap::Skip,
             };
         }
@@ -176,6 +188,7 @@ async fn run_bootstrap(
             return BootstrapOutcome {
                 store,
                 outbox,
+                cache,
                 initial_bootstrap: InitialBootstrap::Skip,
             };
         }
@@ -189,6 +202,7 @@ async fn run_bootstrap(
         return BootstrapOutcome {
             store,
             outbox,
+            cache,
             initial_bootstrap: InitialBootstrap::Run { active: None },
         };
     }
@@ -202,6 +216,9 @@ async fn run_bootstrap(
 
     let active = resolve_active_id(store.as_ref(), &list).await;
     ctx.selected_account.set(active.clone());
+    if let Some(account_id) = active.as_ref() {
+        hydrate_cached_mail(cache.as_ref(), ctx, account_id).await;
+    }
     info!(
         "Bootstrap: {} account(s) from store → Ready (active={:?})",
         list.len(),
@@ -212,7 +229,20 @@ async fn run_bootstrap(
     BootstrapOutcome {
         store,
         outbox,
+        cache,
         initial_bootstrap: InitialBootstrap::Run { active },
+    }
+}
+
+/// Apply a cache hit so the folder tree / list paint before IMAP connects.
+async fn hydrate_cached_mail(cache: &dyn MailCache, ctx: &mut AppContext, account_id: &AccountId) {
+    let sort = *ctx.message_sort.peek();
+    let saved = crate::ui_prefs::load_last_mailbox(account_id);
+    let ack = crate::ui_prefs::load_ack_unread(account_id);
+    match hydrate_account(cache, account_id, sort, saved.as_ref(), &ack).await {
+        Ok(Some(hydrated)) => crate::core_event::apply_hydrated(ctx, hydrated),
+        Ok(None) => {}
+        Err(e) => warn!("mail cache hydrate failed for {account_id}: {e}"),
     }
 }
 
@@ -324,6 +354,7 @@ fn App() -> Element {
                 ctx,
                 outcome.store,
                 outcome.outbox,
+                outcome.cache,
                 outcome.initial_bootstrap,
             )
             .await;

--- a/crates/mailiner-app/src/main.rs
+++ b/crates/mailiner-app/src/main.rs
@@ -16,7 +16,7 @@ use crate::components::{
 };
 use crate::context::AppContext;
 use crate::core_event::{InitialBootstrap, core_loop};
-use crate::mail_cache::{BrowserMailCache, InMemoryMailCache, MailCache, hydrate_account};
+use crate::mail_cache::{BrowserMailCache, InMemoryMailCache, MailCache};
 use crate::outbox_store::{BrowserOutboxStore, InMemoryOutboxStore, OutboxStore};
 
 mod account;
@@ -217,7 +217,7 @@ async fn run_bootstrap(
     let active = resolve_active_id(store.as_ref(), &list).await;
     ctx.selected_account.set(active.clone());
     if let Some(account_id) = active.as_ref() {
-        hydrate_cached_mail(cache.as_ref(), ctx, account_id).await;
+        crate::core_event::hydrate_account_into(cache.as_ref(), ctx, account_id).await;
     }
     info!(
         "Bootstrap: {} account(s) from store → Ready (active={:?})",
@@ -231,18 +231,6 @@ async fn run_bootstrap(
         outbox,
         cache,
         initial_bootstrap: InitialBootstrap::Run { active },
-    }
-}
-
-/// Apply a cache hit so the folder tree / list paint before IMAP connects.
-async fn hydrate_cached_mail(cache: &dyn MailCache, ctx: &mut AppContext, account_id: &AccountId) {
-    let sort = *ctx.message_sort.peek();
-    let saved = crate::ui_prefs::load_last_mailbox(account_id);
-    let ack = crate::ui_prefs::load_ack_unread(account_id);
-    match hydrate_account(cache, account_id, sort, saved.as_ref(), &ack).await {
-        Ok(Some(hydrated)) => crate::core_event::apply_hydrated(ctx, hydrated),
-        Ok(None) => {}
-        Err(e) => warn!("mail cache hydrate failed for {account_id}: {e}"),
     }
 }
 

--- a/crates/mailiner-app/src/toast.rs
+++ b/crates/mailiner-app/src/toast.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use crate::account::AccountId;
 use crate::mailbox::MailboxId;
 use crate::message::{Message, MessageId};
 
@@ -39,6 +40,7 @@ pub enum ToastAction {
     },
     /// Permanent delete. IMAP runs when the toast dismisses unless undone.
     Deleted {
+        account_id: AccountId,
         mailbox_id: MailboxId,
         snapshots: Vec<RemovedMessage>,
     },
@@ -48,6 +50,7 @@ pub enum ToastAction {
 /// Inverse of a move that already succeeded on the server (new dest UIDs).
 #[derive(Clone, Debug)]
 pub struct MoveUndo {
+    pub account_id: AccountId,
     pub from: MailboxId,
     pub to: MailboxId,
     pub dest_ids: Vec<MessageId>,
@@ -66,6 +69,7 @@ pub struct RemovedMessage {
 pub enum UndoRequest {
     ReverseMove(MoveUndo),
     RestoreLocal {
+        account_id: AccountId,
         mailbox_id: MailboxId,
         snapshots: Vec<RemovedMessage>,
     },
@@ -75,6 +79,7 @@ pub enum UndoRequest {
 #[derive(Clone, Debug)]
 pub enum DismissCommit {
     Delete {
+        account_id: AccountId,
         mailbox_id: MailboxId,
         message_ids: Vec<MessageId>,
     },
@@ -104,8 +109,13 @@ impl ToastAction {
         Self::Trashed { undo }
     }
 
-    pub fn deleted(mailbox_id: MailboxId, snapshots: Vec<RemovedMessage>) -> Self {
+    pub fn deleted(
+        account_id: AccountId,
+        mailbox_id: MailboxId,
+        snapshots: Vec<RemovedMessage>,
+    ) -> Self {
         Self::Deleted {
+            account_id,
             mailbox_id,
             snapshots,
         }
@@ -135,9 +145,11 @@ impl ToastAction {
                 Some(UndoRequest::ReverseMove(undo.clone()))
             }
             Self::Deleted {
+                account_id,
                 mailbox_id,
                 snapshots,
             } => Some(UndoRequest::RestoreLocal {
+                account_id: account_id.clone(),
                 mailbox_id: mailbox_id.clone(),
                 snapshots: snapshots.clone(),
             }),
@@ -153,9 +165,11 @@ impl ToastAction {
     pub fn on_dismiss(&self) -> Option<DismissCommit> {
         match self {
             Self::Deleted {
+                account_id,
                 mailbox_id,
                 snapshots,
             } => Some(DismissCommit::Delete {
+                account_id: account_id.clone(),
                 mailbox_id: mailbox_id.clone(),
                 message_ids: snapshots.iter().map(|s| s.message.id.clone()).collect(),
             }),
@@ -214,6 +228,7 @@ mod tests {
     #[test]
     fn moved_pairs_with_reverse_move() {
         let undo = MoveUndo {
+            account_id: AccountId::new("a"),
             from: MailboxId::from("Trash".to_string()),
             to: MailboxId::from("INBOX".to_string()),
             dest_ids: vec![MessageId::new(FolderId::new("INBOX"), "9")],
@@ -232,6 +247,7 @@ mod tests {
     #[test]
     fn deleted_undo_is_local_and_dismiss_commits() {
         let a = ToastAction::deleted(
+            AccountId::new("a"),
             MailboxId::from("Trash".to_string()),
             vec![RemovedMessage {
                 index: 2,

--- a/crates/mailiner-core/src/models.rs
+++ b/crates/mailiner-core/src/models.rs
@@ -79,7 +79,7 @@ pub struct FolderListState {
 }
 
 /// IMAP `STATUS` totals for one mailbox (`MESSAGES` / `UNSEEN`).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FolderCounts {
     pub total_messages: u64,
     pub unread_messages: u64,
@@ -124,7 +124,7 @@ impl MailboxRole {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Folder {
     pub id: FolderId,
     pub account_id: AccountId,


### PR DESCRIPTION
On reload, paint the last mailbox tree and message-list prefix immediately from the browser, then let IMAP connect and replace that snapshot in the background.

## Change
- New `MailCache` trait with `BrowserMailCache` (`localStorage` key `mailiner.cache.v1`) and `InMemoryMailCache` for host tests / storage-blocked sessions
- Hydrate folder tree + last mailbox prefix during bootstrap (and on account switch) **before** `ensure_connected`
- Persist after LIST/STATUS, first-page fetch, prefix-extending range loads, and read/move/delete/undo; invalidate dest folder after a move
- Cache only a **contiguous prefix** (50 messages × 8 folders, LRU) so virtual-scroll `FetchMessageRange` still sees holes beyond the head
- Skip a cached list when the stored sort does not match the current sort
- Keep a cache hit visible if connect or LIST fails

## Limits
- 8 folders per account, 50 envelopes per folder
- Encoded blob capped at ~1.5 MB (evict oldest lists until it fits)

## Tests
Host unit tests cover blob schema, LRU eviction, sort mismatch, hydrate helpers, and SparseList holes after a cached prefix. Live “cache paint → background IMAP swap” was not exercised in a browser here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On reload, the mailbox tree and last message list now paint from a localStorage cache before IMAP connects, then background sync replaces them; previously both waited for the IMAP connection.

**Details**
- New `MailCache` trait with `BrowserMailCache` (`mailiner.cache.v1`) and `InMemoryMailCache` for tests and storage-blocked sessions.
- Hydrates on bootstrap, account switch, and mailbox selection; persists after folder list, page fetch, range loads, and read/move/delete/undo.
- Caches a contiguous prefix (8 folders, 50 messages each) with LRU eviction; virtual scroll still sees holes beyond the head.
- Skips cached lists when the stored sort doesn’t match; keeps cache hits visible if connect or LIST fails.
- Bound undo/dismiss to the originating account so a surviving toast can’t persist another account’s envelopes.
- Clears mailbox UI before hydrating on account switch; keeps live list totals if the first page fetch fails.

**Limits**
- Encoded blob capped at ~1.5 MB; oldest lists are evicted to fit.
- Live browser swap not exercised in tests; host unit tests cover blob, LRU, sort mismatch, hydration, and sparse holes.

<sup>Written for commit 3f4417c55b238db3219547e609b61c0ab96339cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mailiner-net/mailiner-rs/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

